### PR TITLE
Compatibility fix with is_confidential check in league's oauth2-server library

### DIFF
--- a/data/oauth2.sql
+++ b/data/oauth2.sql
@@ -47,6 +47,7 @@ CREATE TABLE `oauth_clients` (
   `personal_access_client` tinyint(1) DEFAULT NULL,
   `password_client` tinyint(1) DEFAULT NULL,
   `revoked` tinyint(1) DEFAULT NULL,
+  `is_confidential` tinyint(1) NOT NULL DEFAULT '0',
   `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
   `updated_at` datetime DEFAULT NULL
 );

--- a/data/oauth2_test.sql
+++ b/data/oauth2_test.sql
@@ -1,6 +1,7 @@
-INSERT INTO oauth_clients (name, secret, redirect, personal_access_client, password_client)
-VALUES ('client_test', '$2y$10$fFlZTo2Syqa./0JJ2QKV4O/Nfi9cqDMcwHBkN/WMcRLLlaxYUP2CK', '/redirect', 1, 1),
-('client_test2', '$2y$10$fFlZTo2Syqa./0JJ2QKV4O/Nfi9cqDMcwHBkN/WMcRLLlaxYUP2CK', '/redirect', 0, 0);
+INSERT INTO oauth_clients (name, secret, redirect, personal_access_client, password_client, is_confidential)
+VALUES ('client_test', '$2y$10$fFlZTo2Syqa./0JJ2QKV4O/Nfi9cqDMcwHBkN/WMcRLLlaxYUP2CK', '/redirect', 1, 1, 1),
+('client_test2', '$2y$10$fFlZTo2Syqa./0JJ2QKV4O/Nfi9cqDMcwHBkN/WMcRLLlaxYUP2CK', '/redirect', 0, 0, 1),
+('client_test_not_confidential', '$2y$10$fFlZTo2Syqa./0JJ2QKV4O/Nfi9cqDMcwHBkN/WMcRLLlaxYUP2CK', '/redirect', 0, 0, 0);
 
 INSERT INTO oauth_users (username, password)
 VALUES ('user_test', '$2y$10$DW12wQQvr4w7mQ.uSmz37OQkKcIZrRZnpXWoYue7b5v8E/pxvsAru');

--- a/src/Entity/ClientEntity.php
+++ b/src/Entity/ClientEntity.php
@@ -35,19 +35,22 @@ class ClientEntity implements ClientEntityInterface
      */
     protected $passwordClient;
 
+
     /**
      * Constructor
      *
-     * @param  string  $identifier
-     * @param  string  $name
-     * @param  string  $redirectUri
+     * @param string $identifier
+     * @param string $name
+     * @param string $redirectUri
+     * @param bool   $isConfidential
      * @return void
      */
-    public function __construct(string $identifier, string $name, string $redirectUri)
+    public function __construct(string $identifier, string $name, string $redirectUri, bool $isConfidential = false)
     {
         $this->setIdentifier($identifier);
         $this->name = $name;
         $this->redirectUri = explode(',', $redirectUri);
+        $this->isConfidential = $isConfidential;
     }
 
     public function getSecret(): string

--- a/src/Repository/Pdo/ClientRepository.php
+++ b/src/Repository/Pdo/ClientRepository.php
@@ -32,7 +32,8 @@ class ClientRepository extends AbstractRepository implements ClientRepositoryInt
         return new ClientEntity(
             $clientIdentifier,
             $clientData['name'] ?? '',
-            $clientData['redirect'] ?? ''
+            $clientData['redirect'] ?? '',
+            (bool) ($clientData['is_confidential'] ?? null)
         );
     }
 

--- a/test/Pdo/OAuth2PdoMiddlewareTest.php
+++ b/test/Pdo/OAuth2PdoMiddlewareTest.php
@@ -155,11 +155,49 @@ class OAuth2PdoMiddlewareTest extends TestCase
     }
 
     /**
-     * Test the Client Credential Grant
+     * Test the Client Credential Grant if client is not confidential
      *
      * @see https://oauth2.thephpleague.com/authorization-server/client-credentials-grant/
      */
-    public function testProcessClientCredentialGrant()
+    public function testProcessClientCredentialGrantNotConfidential()
+    {
+        // Enable the client credentials grant on the server
+        $this->authServer->enableGrantType(
+            new ClientCredentialsGrant(),
+            new DateInterval('PT1H') // access tokens will expire after 1 hour
+        );
+
+        // Server request
+        $params = [
+            'grant_type'    => 'client_credentials',
+            'client_id'     => 'client_test_not_confidential',
+            'client_secret' => 'test',
+            'scope'         => 'test'
+        ];
+        $request = $this->buildServerRequest(
+            'POST',
+            '/access_token',
+            http_build_query($params),
+            $params,
+            [ 'Content-Type' => 'application/x-www-form-urlencoded' ]
+        );
+
+        $handler = new TokenEndpointHandler(
+            $this->authServer,
+            $this->responseFactory
+        );
+
+        $response = $handler->handle($request);
+
+        $this->assertEquals(401, $response->getStatusCode());
+    }
+
+    /**
+     * Test the Client Credential Grant if client is confidential
+     *
+     * @see https://oauth2.thephpleague.com/authorization-server/client-credentials-grant/
+     */
+    public function testProcessClientCredentialGrantConfidential()
     {
         // Enable the client credentials grant on the server
         $this->authServer->enableGrantType(

--- a/test/Pdo/TestAsset/test_data.sql
+++ b/test/Pdo/TestAsset/test_data.sql
@@ -1,6 +1,7 @@
-INSERT INTO oauth_clients (name, secret, redirect, personal_access_client, password_client)
-VALUES ('client_test', '$2y$10$fFlZTo2Syqa./0JJ2QKV4O/Nfi9cqDMcwHBkN/WMcRLLlaxYUP2CK', '/redirect', 1, 1),
-('client_test2', '$2y$10$fFlZTo2Syqa./0JJ2QKV4O/Nfi9cqDMcwHBkN/WMcRLLlaxYUP2CK', '/redirect', 0, 0);
+INSERT INTO oauth_clients (name, secret, redirect, personal_access_client, password_client, is_confidential)
+VALUES ('client_test', '$2y$10$fFlZTo2Syqa./0JJ2QKV4O/Nfi9cqDMcwHBkN/WMcRLLlaxYUP2CK', '/redirect', 1, 1, 1),
+('client_test2', '$2y$10$fFlZTo2Syqa./0JJ2QKV4O/Nfi9cqDMcwHBkN/WMcRLLlaxYUP2CK', '/redirect', 0, 0, 1),
+('client_test_not_confidential', '$2y$10$fFlZTo2Syqa./0JJ2QKV4O/Nfi9cqDMcwHBkN/WMcRLLlaxYUP2CK', '/redirect', 0, 0, 0);
 
 INSERT INTO oauth_users (username, password)
 VALUES ('user_test', '$2y$10$DW12wQQvr4w7mQ.uSmz37OQkKcIZrRZnpXWoYue7b5v8E/pxvsAru');


### PR DESCRIPTION
Signed-off-by: adambalint-srg <adam.balint@srg.hu>

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

The league/oauth2-server library makes an other check in ClientCredentialsGrant. It checks if the client is confidential, and if not, the flow will aborted with 401.

The tests have been failed because of this, so it's fixed in this pull request with some db-structure and test-db content modifications, and with a plus test to check both cases.

