### PR TITLE
Extendable AuthorizationServer without overriding AuthorizationServerFactory

### DIFF
--- a/src/AuthorizationServerFactory.php
+++ b/src/AuthorizationServerFactory.php
@@ -35,7 +35,7 @@ class AuthorizationServerFactory
      *
      * @return AuthorizationServer
      */
-    public function __invoke(ContainerInterface $container, $requestedName) : AuthorizationServer
+    public function __invoke(ContainerInterface $container, $requestedName = AuthorizationServer::class) : AuthorizationServer
     {
         $clientRepository = $this->getClientRepository($container);
         $accessTokenRepository = $this->getAccessTokenRepository($container);

--- a/src/AuthorizationServerFactory.php
+++ b/src/AuthorizationServerFactory.php
@@ -31,10 +31,11 @@ class AuthorizationServerFactory
 
     /**
      * @param ContainerInterface $container
+     * @param string $requestedName
      *
      * @return AuthorizationServer
      */
-    public function __invoke(ContainerInterface $container) : AuthorizationServer
+    public function __invoke(ContainerInterface $container, $requestedName) : AuthorizationServer
     {
         $clientRepository = $this->getClientRepository($container);
         $accessTokenRepository = $this->getAccessTokenRepository($container);
@@ -44,7 +45,7 @@ class AuthorizationServerFactory
         $encryptKey = $this->getEncryptionKey($container);
         $grants = $this->getGrantsConfig($container);
 
-        $authServer = new AuthorizationServer(
+        $authServer = new $requestedName(
             $clientRepository,
             $accessTokenRepository,
             $scopeRepository,

--- a/test/AuthorizationServerFactoryTest.php
+++ b/test/AuthorizationServerFactoryTest.php
@@ -67,7 +67,7 @@ class AuthorizationServerFactoryTest extends TestCase
 
         $factory = new AuthorizationServerFactory();
 
-        $result = $factory($mockContainer->reveal());
+        $result = $factory($mockContainer->reveal(), AuthorizationServer::class);
 
         $this->assertInstanceOf(AuthorizationServer::class, $result);
     }
@@ -117,7 +117,7 @@ class AuthorizationServerFactoryTest extends TestCase
 
         $factory = new AuthorizationServerFactory();
 
-        $result = $factory($mockContainer->reveal());
+        $result = $factory($mockContainer->reveal(), AuthorizationServer::class);
 
         $this->assertInstanceOf(AuthorizationServer::class, $result);
     }
@@ -156,7 +156,7 @@ class AuthorizationServerFactoryTest extends TestCase
 
         $factory = new AuthorizationServerFactory();
 
-        $result = $factory($mockContainer->reveal());
+        $result = $factory($mockContainer->reveal(), AuthorizationServer::class);
 
         $this->assertInstanceOf(AuthorizationServer::class, $result);
     }
@@ -190,7 +190,7 @@ class AuthorizationServerFactoryTest extends TestCase
 
         $this->expectException(InvalidConfigException::class);
 
-        $result = $factory($mockContainer->reveal());
+        $result = $factory($mockContainer->reveal(), AuthorizationServer::class);
     }
 
     public function testInvokeWithListenerProviderConfig()
@@ -218,7 +218,7 @@ class AuthorizationServerFactoryTest extends TestCase
 
         $factory = new AuthorizationServerFactory();
 
-        $result = $factory($mockContainer->reveal());
+        $result = $factory($mockContainer->reveal(), AuthorizationServer::class);
 
         $this->assertInstanceOf(AuthorizationServer::class, $result);
     }
@@ -248,6 +248,6 @@ class AuthorizationServerFactoryTest extends TestCase
         $factory = new AuthorizationServerFactory();
 
         $this->expectException(InvalidConfigException::class);
-        $factory($mockContainer->reveal());
+        $factory($mockContainer->reveal(), AuthorizationServer::class);
     }
 }


### PR DESCRIPTION
Signed-off-by: adambalint-srg <adam.balint@srg.hu>

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

The [AuthorizationServerFactory](https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/src/AuthorizationServerFactory.php) currently does not support to use a custom child class of AuthorizationServer without overriding the whole factory class. The standard factory-pattern of the ServiceManager will provide a requestedName string, so it's easy to create the AuthorizationServer using this class name.

These parameter should be forced by [ServiceManager\Factory\FactoryInterface](https://github.com/laminas/laminas-servicemanager/blob/master/src/Factory/FactoryInterface.php), but this factory already using the Psr-container, and not the old Interop one. As I can see this will be in v4 of ServiceManager, maybe it should be implemented after this.
