### PR TITLE
Update oauth2.sql

### DIFF
--- a/data/oauth2.sql
+++ b/data/oauth2.sql
@@ -39,7 +39,7 @@ CREATE INDEX `IDX_BB493F8319EB6921` ON oauth_auth_codes (`client_id`);
 --
 
 CREATE TABLE `oauth_clients` (
-  `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `id` INT PRIMARY KEY NOT NULL AUTO_INCREMENT,
   `user_id` int(10) DEFAULT NULL,
   `name` varchar(100) NOT NULL,
   `secret` varchar(100) DEFAULT NULL,
@@ -81,7 +81,7 @@ CREATE TABLE `oauth_scopes` (
 --
 
 CREATE TABLE `oauth_users` (
-  `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `id` INTEGER PRIMARY KEY AUTO_INCREMENT NOT NULL,
   `username` varchar(320) UNIQUE NOT NULL,
   `password` varchar(100) NOT NULL,
   `first_name` varchar(80) DEFAULT NULL,

--- a/data/oauth2.sql
+++ b/data/oauth2.sql
@@ -79,7 +79,6 @@ CREATE TABLE `oauth_scopes` (
 --
 -- Table structure for table `oauth_users`
 --
-
 CREATE TABLE `oauth_users` (
   `id` INTEGER PRIMARY KEY AUTO_INCREMENT NOT NULL,
   `username` varchar(320) UNIQUE NOT NULL,


### PR DESCRIPTION
Correction of the keyword "autoincrement" in the creation of the necessary tables.


|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description
Corrects SQL create syntax on auto_increment keywords