### PR TITLE
Fix key generator, to support PHP8 'resource to object' migration

### DIFF
--- a/bin/generate-oauth2-keys
+++ b/bin/generate-oauth2-keys
@@ -73,7 +73,7 @@ printf('Using %d bits to generate key of type RSA' . "\n\n", $bits);
 // Private key
 $res = openssl_pkey_new($config);
 
-if (!is_resource($res)) {
+if (!(is_resource($res) || (is_object($res) && $res instanceof OpenSSLAsymmetricKey))) {
     fwrite(STDERR, 'Failed to create private key.' . PHP_EOL);
     fwrite(STDERR, 'Check your openssl extension settings.' . PHP_EOL);
     exit(1);


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

In PHP8 some resources (like in case of OpenSSL lib) have been replaced to objects. With this change the return value of openssl_pkey_new function won't be a resource, but an object with class OpenSSLAsymmetricKey.

In key generator I've fixed this, but it will work with resources as well, so it supports older PHP versions.
