### PR TITLE
Fixes fatal error in `generate-oauth2-keys` (#26)

### DIFF
--- a/bin/generate-oauth2-keys
+++ b/bin/generate-oauth2-keys
@@ -29,8 +29,10 @@ if (!extension_loaded('openssl')) {
 
 // find the best dir
 if (
+    // get path of data dir of the parent application
+    ($dataDir = realpath(__DIR__ . '/../../../../data'))
     // see if there's a data dir of the parent application
-    file_exists($dataDir = realpath(__DIR__ . '/../../../../data'))
+    && file_exists($dataDir)
 ) {
     printf("Found a good location for keys:\n%s\n\n", $dataDir);
 } elseif (


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Сheck `dataDir` variable before using in the `file_exists` function.
Fixes fatal error in `generate-oauth2-keys` command (#26).

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
