### PR TITLE
Import ScopeEntityInterface from League

### DIFF
--- a/src/Repository/Pdo/AbstractRepository.php
+++ b/src/Repository/Pdo/AbstractRepository.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Repository\Pdo;
 
+use League\OAuth2\Server\Entities\ScopeEntityInterface;
 use function array_reduce;
 use function trim;
 


### PR DESCRIPTION
Currently `ScopeEntityInterface` is not imported from the League package.
This means that psalm fails:
"Argument 1 of App\Repository\AuthCodeRepository::scopesToString expects array<array-key, Mezzio\Authentication\OAuth2\Repository\Pdo\ScopeEntityInterface>, array<array-key, League\OAuth2\Server\Entities\ScopeEntityInterface> provided (see https://psalm.dev/004)"

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no