### PR TITLE
Add Body Parsing Middleware reference

### DIFF
--- a/docs/book/v1/authorization-server.md
+++ b/docs/book/v1/authorization-server.md
@@ -26,12 +26,6 @@ To enable the token endpoint to handle the POST requests in JSON, the [Body Pars
 For example:
 
 ```php
-use Mezzio\Helper\BodyParams\BodyParamsMiddleware;
-
-$app->pipe(BodyParamsMiddleware::class);
-```
-Generally speaking, we recommend AGAINST piping the body parsing middleware as generic middleware; instead, we recommend piping it into a route-specific pipeline:
-```php
 use Mezzio\Authentication\OAuth2;
 use Mezzio\Helper\BodyParams\BodyParamsMiddleware;
 
@@ -40,7 +34,8 @@ $app->post('/oauth2/token', [
     OAuth2\TokenEndpointHandler::class
 ], 'auth.token');
 ```
-This ensures we only parse it when we are actually expecting a content body.
+WARNING: Do not pipe the body parsing middleware as generic middleware.
+This ensures that the content body is only parsed when it is actually expected.
 
 ## Add the authorization endpoint
 

--- a/docs/book/v1/authorization-server.md
+++ b/docs/book/v1/authorization-server.md
@@ -22,7 +22,15 @@ use Mezzio\Authentication\OAuth2;
 $app->post('/oauth2/token', OAuth2\TokenEndpointHandler::class);
 ```
 ## Parsing JSON payloads in the token endpoint
-To enable the token endpoint to handle the POST requests in JSON, the [Body Parsing Middleware](https://docs.mezzio.dev/mezzio/v3/features/helpers/body-parse/) helper should be included in the application. 
+To enable the token endpoint to handle the POST requests in JSON, the [Body Parsing Middleware](https://docs.mezzio.dev/mezzio/v3/features/helpers/body-parse/) helper must be included in the application. 
+
+For example:
+
+```php
+use Mezzio\Helper\BodyParams\BodyParamsMiddleware;
+
+$app->pipe(BodyParamsMiddleware::class);
+```
 
 ## Add the authorization endpoint
 

--- a/docs/book/v1/authorization-server.md
+++ b/docs/book/v1/authorization-server.md
@@ -6,6 +6,8 @@ for your application.
 Since there are authorization flows that require user interaction,
 **your application is expected to provide the middleware to handle this**.
 
+To enable the authorization server to parse the requests from JSON, the [Body Parsing Middleware](https://docs.mezzio.dev/mezzio/v3/features/helpers/body-parse/) helper should be included in the application. 
+
 ## Add the token endpoint
 
 Adding the token endpoint involves routing to the provided

--- a/docs/book/v1/authorization-server.md
+++ b/docs/book/v1/authorization-server.md
@@ -6,7 +6,6 @@ for your application.
 Since there are authorization flows that require user interaction,
 **your application is expected to provide the middleware to handle this**.
 
-To enable the authorization server to parse the requests from JSON, the [Body Parsing Middleware](https://docs.mezzio.dev/mezzio/v3/features/helpers/body-parse/) helper should be included in the application. 
 
 ## Add the token endpoint
 
@@ -22,6 +21,8 @@ use Mezzio\Authentication\OAuth2;
 
 $app->post('/oauth2/token', OAuth2\TokenEndpointHandler::class);
 ```
+## Parsing JSON payloads in the token endpoint
+To enable the token endpoint to handle the POST requests in JSON, the [Body Parsing Middleware](https://docs.mezzio.dev/mezzio/v3/features/helpers/body-parse/) helper should be included in the application. 
 
 ## Add the authorization endpoint
 

--- a/docs/book/v1/authorization-server.md
+++ b/docs/book/v1/authorization-server.md
@@ -6,7 +6,6 @@ for your application.
 Since there are authorization flows that require user interaction,
 **your application is expected to provide the middleware to handle this**.
 
-
 ## Add the token endpoint
 
 Adding the token endpoint involves routing to the provided
@@ -31,6 +30,17 @@ use Mezzio\Helper\BodyParams\BodyParamsMiddleware;
 
 $app->pipe(BodyParamsMiddleware::class);
 ```
+Generally speaking, we recommend AGAINST piping the body parsing middleware as generic middleware; instead, we recommend piping it into a route-specific pipeline:
+```php
+use Mezzio\Authentication\OAuth2;
+use Mezzio\Helper\BodyParams\BodyParamsMiddleware;
+
+$app->post('/oauth2/token', [
+    BodyParamsMiddleware::class,
+    OAuth2\TokenEndpointHandler::class
+], 'auth.token');
+```
+This ensures we only parse it when we are actually expecting a content body.
 
 ## Add the authorization endpoint
 


### PR DESCRIPTION
Mention the requirement for Body Parsing Middleware when parsing application/json requests

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description
When requesting an access token from the authentication server using JSON, the response from the server will always be  "error": "unsupported_grant_type" unless the body parsing middleware helper is included in the application. Updating the docs to highlight the requirement for this library.

Fixes #39

