### PR TITLE
Update laminas-coding-standard to v2.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.phpcs-cache
 /.phpunit.result.cache
 /clover.xml
 /coveralls-upload.json

--- a/bin/generate-oauth2-keys
+++ b/bin/generate-oauth2-keys
@@ -2,13 +2,6 @@
 <?php
 
 declare(strict_types=1);
-/*
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- *
- * @copyright Copyright (c) 2017 Laminas (https://www.zend.com)
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md
- *     New BSD License
- */
 
 /*
  * Script to generate public, private and encryption keys for thephpleague/oauth2-server.

--- a/composer.json
+++ b/composer.json
@@ -43,12 +43,11 @@
         "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {
-        "laminas/laminas-coding-standard": "~1.0.0",
-        "squizlabs/php_codesniffer": "3.6.2 as 2.9.9999999",
+        "laminas/laminas-coding-standard": "~2.3.0",
         "laminas/laminas-diactoros": "^1.4.0 || ^2.0",
         "laminas/laminas-servicemanager": "^3.10.0",
-        "phpunit/phpunit": "^9.5.11",
-        "phpspec/prophecy-phpunit": "^2.0"
+        "phpspec/prophecy-phpunit": "^2.0",
+        "phpunit/phpunit": "^9.5.11"
     },
     "conflict": {
         "container-interop/container-interop": "<1.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "06e1e9f3ecd9d0b35c11f2ad35884573",
+    "content-hash": "404aa631f5e8950a8e04fe36c2c7f0aa",
     "packages": [
         {
             "name": "defuse/php-encryption",
@@ -697,7 +697,7 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.24.0",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -729,12 +729,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -759,7 +759,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.24.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.25.0"
             },
             "funding": [
                 {
@@ -874,30 +874,106 @@
             "time": "2017-02-14T19:40:03+00:00"
         },
         {
-            "name": "doctrine/instantiator",
-            "version": "1.4.0",
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.7.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b"
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/d56bf6102915de5702778fe20f2de3b2fe570b5b",
-                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcbf",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2022-02-04T12:51:07+00:00"
+        },
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/10dcfce151b967d20fde1b34ae6640712c3891bc",
+                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^8.0",
+                "doctrine/coding-standard": "^9",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.13 || 1.0.0-alpha2",
-                "phpstan/phpstan": "^0.12",
-                "phpstan/phpstan-phpunit": "^0.12",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+                "phpbench/phpbench": "^0.16 || ^1",
+                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.22"
             },
             "type": "library",
             "autoload": {
@@ -924,7 +1000,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.4.0"
+                "source": "https://github.com/doctrine/instantiator/tree/1.4.1"
             },
             "funding": [
                 {
@@ -940,35 +1016,40 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-10T18:47:58+00:00"
+            "time": "2022-03-03T08:28:38+00:00"
         },
         {
             "name": "laminas/laminas-coding-standard",
-            "version": "1.0.0",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-coding-standard.git",
-                "reference": "08880ce2fbfe62d471cd3cb766a91da630b32539"
+                "reference": "bcf6e07fe4690240be7beb6d884d0b0fafa6a251"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/08880ce2fbfe62d471cd3cb766a91da630b32539",
-                "reference": "08880ce2fbfe62d471cd3cb766a91da630b32539",
+                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/bcf6e07fe4690240be7beb6d884d0b0fafa6a251",
+                "reference": "bcf6e07fe4690240be7beb6d884d0b0fafa6a251",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "squizlabs/php_codesniffer": "^2.7"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+                "php": "^7.3 || ^8.0",
+                "slevomat/coding-standard": "^7.0",
+                "squizlabs/php_codesniffer": "^3.6",
+                "webimpress/coding-standard": "^1.2"
             },
-            "replace": {
-                "zendframework/zend-coding-standard": "self.version"
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "LaminasCodingStandard\\": "src/LaminasCodingStandard/"
+                }
             },
-            "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
-            "description": "Laminas coding standard",
+            "description": "Laminas Coding Standard",
             "homepage": "https://laminas.dev",
             "keywords": [
                 "Coding Standard",
@@ -982,20 +1063,26 @@
                 "rss": "https://github.com/laminas/laminas-coding-standard/releases.atom",
                 "source": "https://github.com/laminas/laminas-coding-standard"
             },
-            "time": "2019-12-31T16:28:26+00:00"
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2021-05-29T15:53:59+00:00"
         },
         {
             "name": "laminas/laminas-diactoros",
-            "version": "2.8.0",
+            "version": "2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-diactoros.git",
-                "reference": "0c26ef1d95b6d7e6e3943a243ba3dc0797227199"
+                "reference": "954e2dcfb1607681be44599faac10fc63bb6925a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/0c26ef1d95b6d7e6e3943a243ba3dc0797227199",
-                "reference": "0c26ef1d95b6d7e6e3943a243ba3dc0797227199",
+                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/954e2dcfb1607681be44599faac10fc63bb6925a",
+                "reference": "954e2dcfb1607681be44599faac10fc63bb6925a",
                 "shasum": ""
             },
             "require": {
@@ -1081,7 +1168,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-09-22T03:54:36+00:00"
+            "time": "2022-03-29T20:12:16+00:00"
         },
         {
             "name": "laminas/laminas-servicemanager",
@@ -1229,88 +1316,30 @@
             "time": "2022-01-21T15:50:46+00:00"
         },
         {
-            "name": "laminas/laminas-zendframework-bridge",
-            "version": "1.4.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
-                "reference": "88bf037259869891afce6504cacc4f8a07b24d0f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/88bf037259869891afce6504cacc4f8a07b24d0f",
-                "reference": "88bf037259869891afce6504cacc4f8a07b24d0f",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.3 || ~8.0.0 || ~8.1.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3",
-                "psalm/plugin-phpunit": "^0.15.1",
-                "squizlabs/php_codesniffer": "^3.5",
-                "vimeo/psalm": "^4.6"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "module": "Laminas\\ZendFrameworkBridge"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/autoload.php"
-                ],
-                "psr-4": {
-                    "Laminas\\ZendFrameworkBridge\\": "src//"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Alias legacy ZF class names to Laminas Project equivalents.",
-            "keywords": [
-                "ZendFramework",
-                "autoloading",
-                "laminas",
-                "zf"
-            ],
-            "support": {
-                "forum": "https://discourse.laminas.dev/",
-                "issues": "https://github.com/laminas/laminas-zendframework-bridge/issues",
-                "rss": "https://github.com/laminas/laminas-zendframework-bridge/releases.atom",
-                "source": "https://github.com/laminas/laminas-zendframework-bridge"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2021-12-21T14:34:37+00:00"
-        },
-        {
             "name": "myclabs/deep-copy",
-            "version": "1.10.2",
+            "version": "1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220"
+                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/776f831124e9c62e1a2c601ecc52e776d8bb7220",
-                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/14daed4296fae74d9e3201d2c4925d1acb7aa614",
+                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3,<3.2.2"
+            },
             "require-dev": {
-                "doctrine/collections": "^1.0",
-                "doctrine/common": "^2.6",
-                "phpunit/phpunit": "^7.1"
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
             },
             "type": "library",
             "autoload": {
@@ -1335,7 +1364,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.10.2"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.0"
             },
             "funding": [
                 {
@@ -1343,7 +1372,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-13T09:40:50+00:00"
+            "time": "2022-03-03T13:19:32+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -1463,16 +1492,16 @@
         },
         {
             "name": "phar-io/version",
-            "version": "3.1.1",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "15a90844ad40f127afd244c0cad228de2a80052a"
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/15a90844ad40f127afd244c0cad228de2a80052a",
-                "reference": "15a90844ad40f127afd244c0cad228de2a80052a",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
                 "shasum": ""
             },
             "require": {
@@ -1508,9 +1537,9 @@
             "description": "Library for handling version information and constraints",
             "support": {
                 "issues": "https://github.com/phar-io/version/issues",
-                "source": "https://github.com/phar-io/version/tree/3.1.1"
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
-            "time": "2022-02-07T21:56:48+00:00"
+            "time": "2022-02-21T01:04:05+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -1624,16 +1653,16 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.6.0",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "93ebd0014cab80c4ea9f5e297ea48672f1b87706"
+                "reference": "77a32518733312af16a44300404e945338981de3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/93ebd0014cab80c4ea9f5e297ea48672f1b87706",
-                "reference": "93ebd0014cab80c4ea9f5e297ea48672f1b87706",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/77a32518733312af16a44300404e945338981de3",
+                "reference": "77a32518733312af16a44300404e945338981de3",
                 "shasum": ""
             },
             "require": {
@@ -1668,9 +1697,9 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.0"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.1"
             },
-            "time": "2022-01-04T19:58:01+00:00"
+            "time": "2022-03-15T21:29:03+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -1792,17 +1821,61 @@
             "time": "2020-07-09T08:33:42+00:00"
         },
         {
-            "name": "phpunit/php-code-coverage",
-            "version": "9.2.11",
+            "name": "phpstan/phpdoc-parser",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "665a1ac0a763c51afc30d6d130dac0813092b17f"
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "4cb3021a4e10ffe3d5f94a4c34cf4b3f6de2fa3d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/665a1ac0a763c51afc30d6d130dac0813092b17f",
-                "reference": "665a1ac0a763c51afc30d6d130dac0813092b17f",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/4cb3021a4e10ffe3d5f94a4c34cf4b3f6de2fa3d",
+                "reference": "4cb3021a4e10ffe3d5f94a4c34cf4b3f6de2fa3d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^1.5",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.4.2"
+            },
+            "time": "2022-03-30T13:33:37+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.15",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "2e9da11878c4202f97915c1cb4bb1ca318a63f5f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2e9da11878c4202f97915c1cb4bb1ca318a63f5f",
+                "reference": "2e9da11878c4202f97915c1cb4bb1ca318a63f5f",
                 "shasum": ""
             },
             "require": {
@@ -1858,7 +1931,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.11"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.15"
             },
             "funding": [
                 {
@@ -1866,7 +1939,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-18T12:46:09+00:00"
+            "time": "2022-03-07T09:28:20+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -2111,16 +2184,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.14",
+            "version": "9.5.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "1883687169c017d6ae37c58883ca3994cfc34189"
+                "reference": "35ea4b7f3acabb26f4bb640f8c30866c401da807"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/1883687169c017d6ae37c58883ca3994cfc34189",
-                "reference": "1883687169c017d6ae37c58883ca3994cfc34189",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/35ea4b7f3acabb26f4bb640f8c30866c401da807",
+                "reference": "35ea4b7f3acabb26f4bb640f8c30866c401da807",
                 "shasum": ""
             },
             "require": {
@@ -2136,7 +2209,7 @@
                 "phar-io/version": "^3.0.2",
                 "php": ">=7.3",
                 "phpspec/prophecy": "^1.12.1",
-                "phpunit/php-code-coverage": "^9.2.7",
+                "phpunit/php-code-coverage": "^9.2.13",
                 "phpunit/php-file-iterator": "^3.0.5",
                 "phpunit/php-invoker": "^3.1.1",
                 "phpunit/php-text-template": "^2.0.3",
@@ -2150,7 +2223,7 @@
                 "sebastian/global-state": "^5.0.1",
                 "sebastian/object-enumerator": "^4.0.3",
                 "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^2.3.4",
+                "sebastian/type": "^3.0",
                 "sebastian/version": "^3.0.2"
             },
             "require-dev": {
@@ -2198,7 +2271,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.14"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.19"
             },
             "funding": [
                 {
@@ -2210,7 +2283,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-18T12:54:07+00:00"
+            "time": "2022-03-15T09:57:31+00:00"
         },
         {
             "name": "psr/http-factory",
@@ -3124,28 +3197,28 @@
         },
         {
             "name": "sebastian/type",
-            "version": "2.3.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914"
+                "reference": "b233b84bc4465aff7b57cf1c4bc75c86d00d6dad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/b8cd8a1c753c90bc1a0f5372170e3e489136f914",
-                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/b233b84bc4465aff7b57cf1c4bc75c86d00d6dad",
+                "reference": "b233b84bc4465aff7b57cf1c4bc75c86d00d6dad",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^9.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -3168,7 +3241,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/2.3.4"
+                "source": "https://github.com/sebastianbergmann/type/tree/3.0.0"
             },
             "funding": [
                 {
@@ -3176,7 +3249,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-06-15T12:49:02+00:00"
+            "time": "2022-03-15T09:54:48+00:00"
         },
         {
             "name": "sebastian/version",
@@ -3230,6 +3303,67 @@
                 }
             ],
             "time": "2020-09-28T06:39:44+00:00"
+        },
+        {
+            "name": "slevomat/coding-standard",
+            "version": "7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "b521bd358b5f7a7d69e9637fd139e036d8adeb6f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/b521bd358b5f7a7d69e9637fd139e036d8adeb6f",
+                "reference": "b521bd358b5f7a7d69e9637fd139e036d8adeb6f",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpdoc-parser": "^1.4.1",
+                "squizlabs/php_codesniffer": "^3.6.2"
+            },
+            "require-dev": {
+                "phing/phing": "2.17.2",
+                "php-parallel-lint/php-parallel-lint": "1.3.2",
+                "phpstan/phpstan": "1.4.10|1.5.2",
+                "phpstan/phpstan-deprecation-rules": "1.0.0",
+                "phpstan/phpstan-phpunit": "1.0.0|1.1.0",
+                "phpstan/phpstan-strict-rules": "1.1.0",
+                "phpunit/phpunit": "7.5.20|8.5.21|9.5.19"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/7.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-03-29T12:44:16+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -3336,16 +3470,64 @@
                 }
             ],
             "time": "2021-07-28T10:34:58+00:00"
-        }
-    ],
-    "aliases": [
+        },
         {
-            "package": "squizlabs/php_codesniffer",
-            "version": "3.6.2.0",
-            "alias": "2.9.9999999",
-            "alias_normalized": "2.9.9999999.0"
+            "name": "webimpress/coding-standard",
+            "version": "1.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webimpress/coding-standard.git",
+                "reference": "cd0c4b0b97440c337c1f7da17b524674ca2f9ca9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/cd0c4b0b97440c337c1f7da17b524674ca2f9ca9",
+                "reference": "cd0c4b0b97440c337c1f7da17b524674ca2f9ca9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8.0",
+                "squizlabs/php_codesniffer": "^3.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5.13"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "dev-master": "1.2.x-dev",
+                "dev-develop": "1.3.x-dev"
+            },
+            "autoload": {
+                "psr-4": {
+                    "WebimpressCodingStandard\\": "src/WebimpressCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "description": "Webimpress Coding Standard",
+            "keywords": [
+                "Coding Standard",
+                "PSR-2",
+                "phpcs",
+                "psr-12",
+                "webimpress"
+            ],
+            "support": {
+                "issues": "https://github.com/webimpress/coding-standard/issues",
+                "source": "https://github.com/webimpress/coding-standard/tree/1.2.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/michalbundyra",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-02-15T19:52:12+00:00"
         }
     ],
+    "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],
     "prefer-stable": false,

--- a/config/oauth2.php
+++ b/config/oauth2.php
@@ -1,14 +1,18 @@
 <?php
+
+declare(strict_types=1);
+
  /**
- * To generate a private key run this command:
- * openssl genrsa -out private.key 1024
- *
- * To generate the encryption key use this command:
- * php -r 'echo base64_encode(random_bytes(32)), PHP_EOL;'
- *
- * The expire values must be a valid DateInterval format
- * @see http://php.net/manual/en/class.dateinterval.php
- */
+  * To generate a private key run this command:
+  * openssl genrsa -out private.key 1024
+  *
+  * To generate the encryption key use this command:
+  * php -r 'echo base64_encode(random_bytes(32)), PHP_EOL;'
+  *
+  * The expire values must be a valid DateInterval format
+  *
+  * @see http://php.net/manual/en/class.dateinterval.php
+  */
 
 $config = [
     'private_key'          => getcwd() . '/data/oauth/private.key',
@@ -16,10 +20,10 @@ $config = [
     'access_token_expire'  => 'P1D', // 1 day in DateInterval format
     'refresh_token_expire' => 'P1M', // 1 month in DateInterval format
     'auth_code_expire'     => 'PT10M', // 10 minutes in DateInterval format
-    'pdo' => [
+    'pdo'                  => [
         'dsn'      => '',
         'username' => '',
-        'password' => ''
+        'password' => '',
     ],
 
     // Set value to null to disable a grant
@@ -33,7 +37,7 @@ $config = [
         League\OAuth2\Server\Grant\ImplicitGrant::class
             => League\OAuth2\Server\Grant\ImplicitGrant::class,
         League\OAuth2\Server\Grant\RefreshTokenGrant::class
-            => League\OAuth2\Server\Grant\RefreshTokenGrant::class
+            => League\OAuth2\Server\Grant\RefreshTokenGrant::class,
     ],
 ];
 

--- a/config/oauth2.php
+++ b/config/oauth2.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
  /**
   * To generate a private key run this command:
   * openssl genrsa -out private.key 1024
@@ -13,6 +11,8 @@ declare(strict_types=1);
   *
   * @see http://php.net/manual/en/class.dateinterval.php
   */
+
+declare(strict_types=1);
 
 $config = [
     'private_key'          => getcwd() . '/data/oauth/private.key',

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,9 +1,21 @@
 <?xml version="1.0"?>
-<ruleset name="Laminas coding standard">
-    <rule ref="./vendor/laminas/laminas-coding-standard/ruleset.xml"/>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
+    <arg name="basepath" value="."/>
+    <arg name="cache" value=".phpcs-cache"/>
+    <arg name="colors"/>
+    <arg name="extensions" value="php"/>
+    <arg name="parallel" value="80"/>
+
+    <!-- Show progress -->
+    <arg value="p"/>
 
     <!-- Paths to check -->
-    <file>bin</file>
+    <file>config</file>
     <file>src</file>
     <file>test</file>
+
+    <!-- Include all rules from the Laminas Coding Standard -->
+    <rule ref="LaminasCodingStandard"/>
 </ruleset>

--- a/src/AuthorizationHandler.php
+++ b/src/AuthorizationHandler.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -12,7 +10,6 @@ namespace Mezzio\Authentication\OAuth2;
 
 use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\RequestTypes\AuthorizationRequest;
-use phpDocumentor\Reflection\Types\This;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -28,19 +25,15 @@ use Psr\Http\Server\RequestHandlerInterface;
  */
 class AuthorizationHandler implements RequestHandlerInterface
 {
-    /**
-     * @var AuthorizationServer
-     */
+    /** @var AuthorizationServer */
     private $server;
 
-    /**
-     * @var callable
-     */
+    /** @var callable */
     private $responseFactory;
 
     public function __construct(AuthorizationServer $server, callable $responseFactory)
     {
-        $this->server = $server;
+        $this->server          = $server;
         $this->responseFactory = function () use ($responseFactory): ResponseInterface {
             return $responseFactory();
         };

--- a/src/AuthorizationHandler.php
+++ b/src/AuthorizationHandler.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2;

--- a/src/AuthorizationHandlerFactory.php
+++ b/src/AuthorizationHandlerFactory.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/src/AuthorizationHandlerFactory.php
+++ b/src/AuthorizationHandlerFactory.php
@@ -14,7 +14,7 @@ use Psr\Http\Message\ResponseInterface;
 
 final class AuthorizationHandlerFactory
 {
-    public function __invoke(ContainerInterface $container)
+    public function __invoke(ContainerInterface $container): AuthorizationHandler
     {
         return new AuthorizationHandler(
             $container->get(AuthorizationServer::class),

--- a/src/AuthorizationHandlerFactory.php
+++ b/src/AuthorizationHandlerFactory.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2;

--- a/src/AuthorizationMiddleware.php
+++ b/src/AuthorizationMiddleware.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2;

--- a/src/AuthorizationMiddleware.php
+++ b/src/AuthorizationMiddleware.php
@@ -2,14 +2,13 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2;
 
+use Exception;
 use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\RequestTypes\AuthorizationRequest;
@@ -34,20 +33,16 @@ use Psr\Http\Server\RequestHandlerInterface;
  */
 class AuthorizationMiddleware implements MiddlewareInterface
 {
-    /**
-     * @var AuthorizationServer
-     */
+    /** @var AuthorizationServer */
     protected $server;
 
-    /**
-     * @var callable
-     */
+    /** @var callable */
     protected $responseFactory;
 
     public function __construct(AuthorizationServer $server, callable $responseFactory)
     {
-        $this->server = $server;
-        $this->responseFactory = function () use ($responseFactory) : ResponseInterface {
+        $this->server          = $server;
+        $this->responseFactory = function () use ($responseFactory): ResponseInterface {
             return $responseFactory();
         };
     }
@@ -55,7 +50,7 @@ class AuthorizationMiddleware implements MiddlewareInterface
     /**
      * {@inheritDoc}
      */
-    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $response = ($this->responseFactory)();
 
@@ -71,7 +66,7 @@ class AuthorizationMiddleware implements MiddlewareInterface
             // The validation throws this exception if the request is not valid
             // for example when the client id is invalid
             return $exception->generateHttpResponse($response);
-        } catch (\Exception $exception) {
+        } catch (Exception $exception) {
             return (new OAuthServerException($exception->getMessage(), 0, 'unknown_error', 500))
                 ->generateHttpResponse($response);
         }

--- a/src/AuthorizationMiddlewareFactory.php
+++ b/src/AuthorizationMiddlewareFactory.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2;

--- a/src/AuthorizationMiddlewareFactory.php
+++ b/src/AuthorizationMiddlewareFactory.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -16,7 +14,7 @@ use Psr\Http\Message\ResponseInterface;
 
 final class AuthorizationMiddlewareFactory
 {
-    public function __invoke(ContainerInterface $container) : AuthorizationMiddleware
+    public function __invoke(ContainerInterface $container): AuthorizationMiddleware
     {
         return new AuthorizationMiddleware(
             $container->get(AuthorizationServer::class),

--- a/src/AuthorizationServerFactory.php
+++ b/src/AuthorizationServerFactory.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2;

--- a/src/AuthorizationServerFactory.php
+++ b/src/AuthorizationServerFactory.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -11,9 +9,11 @@ declare(strict_types=1);
 namespace Mezzio\Authentication\OAuth2;
 
 use DateInterval;
-use League\Event\ListenerProviderInterface;
 use League\OAuth2\Server\AuthorizationServer;
 use Psr\Container\ContainerInterface;
+
+use function is_string;
+use function sprintf;
 
 /**
  * Factory for OAuth AuthorizationServer
@@ -29,20 +29,15 @@ class AuthorizationServerFactory
     use CryptKeyTrait;
     use RepositoryTrait;
 
-    /**
-     * @param ContainerInterface $container
-     *
-     * @return AuthorizationServer
-     */
-    public function __invoke(ContainerInterface $container) : AuthorizationServer
+    public function __invoke(ContainerInterface $container): AuthorizationServer
     {
-        $clientRepository = $this->getClientRepository($container);
+        $clientRepository      = $this->getClientRepository($container);
         $accessTokenRepository = $this->getAccessTokenRepository($container);
-        $scopeRepository = $this->getScopeRepository($container);
+        $scopeRepository       = $this->getScopeRepository($container);
 
         $privateKey = $this->getCryptKey($this->getPrivateKey($container), 'authentication.private_key');
         $encryptKey = $this->getEncryptionKey($container);
-        $grants = $this->getGrantsConfig($container);
+        $grants     = $this->getGrantsConfig($container);
 
         $authServer = new AuthorizationServer(
             $clientRepository,
@@ -77,9 +72,6 @@ class AuthorizationServerFactory
 
     /**
      * Optionally add event listeners
-     *
-     * @param AuthorizationServer $authServer
-     * @param ContainerInterface  $container
      */
     private function addListeners(
         AuthorizationServer $authServer,
@@ -88,16 +80,16 @@ class AuthorizationServerFactory
         $listeners = $this->getListenersConfig($container);
 
         foreach ($listeners as $idx => $listenerConfig) {
-            $event = $listenerConfig[0];
+            $event    = $listenerConfig[0];
             $listener = $listenerConfig[1];
             $priority = $listenerConfig[2] ?? null;
             if (is_string($listener)) {
                 if (! $container->has($listener)) {
                     throw new Exception\InvalidConfigException(sprintf(
-                        'The second element of event_listeners config at ' .
-                            'index "%s" is a string and therefore expected to ' .
-                            'be available as a service key in the container. ' .
-                            'A service named "%s" was not found.',
+                        'The second element of event_listeners config at '
+                            . 'index "%s" is a string and therefore expected to '
+                            . 'be available as a service key in the container. '
+                            . 'A service named "%s" was not found.',
                         $idx,
                         $listener
                     ));
@@ -111,9 +103,6 @@ class AuthorizationServerFactory
 
     /**
      * Optionally add event listener providers
-     *
-     * @param AuthorizationServer       $authServer
-     * @param ContainerInterface $container
      */
     private function addListenerProviders(
         AuthorizationServer $authServer,
@@ -125,10 +114,10 @@ class AuthorizationServerFactory
             if (is_string($provider)) {
                 if (! $container->has($provider)) {
                     throw new Exception\InvalidConfigException(sprintf(
-                        'The event_listener_providers config at ' .
-                            'index "%s" is a string and therefore expected to ' .
-                            'be available as a service key in the container. ' .
-                            'A service named "%s" was not found.',
+                        'The event_listener_providers config at '
+                            . 'index "%s" is a string and therefore expected to '
+                            . 'be available as a service key in the container. '
+                            . 'A service named "%s" was not found.',
                         $idx,
                         $provider
                     ));

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2;

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -39,30 +37,30 @@ class ConfigProvider
     /**
      * Return the configuration array.
      */
-    public function __invoke() : array
+    public function __invoke(): array
     {
         return [
             'dependencies'   => $this->getDependencies(),
             'authentication' => include __DIR__ . '/../config/oauth2.php',
-            'routes'         => $this->getRoutes()
+            'routes'         => $this->getRoutes(),
         ];
     }
 
     /**
      * Returns the container dependencies
      */
-    public function getDependencies() : array
+    public function getDependencies(): array
     {
         return [
-            'aliases' => [
+            'aliases'   => [
                 // Choose a different adapter changing the alias value
-                AccessTokenRepositoryInterface::class => Pdo\AccessTokenRepository::class,
-                AuthCodeRepositoryInterface::class => Pdo\AuthCodeRepository::class,
-                ClientRepositoryInterface::class => Pdo\ClientRepository::class,
+                AccessTokenRepositoryInterface::class  => Pdo\AccessTokenRepository::class,
+                AuthCodeRepositoryInterface::class     => Pdo\AuthCodeRepository::class,
+                ClientRepositoryInterface::class       => Pdo\ClientRepository::class,
                 RefreshTokenRepositoryInterface::class => Pdo\RefreshTokenRepository::class,
-                ScopeRepositoryInterface::class => Pdo\ScopeRepository::class,
-                UserRepositoryInterface::class => Pdo\UserRepository::class,
-                AuthenticationInterface::class => OAuth2Adapter::class,
+                ScopeRepositoryInterface::class        => Pdo\ScopeRepository::class,
+                UserRepositoryInterface::class         => Pdo\UserRepository::class,
+                AuthenticationInterface::class         => OAuth2Adapter::class,
 
                 // Legacy Zend Framework aliases
                 // @codingStandardsIgnoreStart
@@ -83,37 +81,37 @@ class ConfigProvider
             ],
             'factories' => [
                 AuthorizationMiddleware::class => AuthorizationMiddlewareFactory::class,
-                AuthorizationHandler::class => AuthorizationHandlerFactory::class,
-                TokenEndpointHandler::class => TokenEndpointHandlerFactory::class,
-                OAuth2Adapter::class => OAuth2AdapterFactory::class,
-                AuthorizationServer::class => AuthorizationServerFactory::class,
-                ResourceServer::class => ResourceServerFactory::class,
+                AuthorizationHandler::class    => AuthorizationHandlerFactory::class,
+                TokenEndpointHandler::class    => TokenEndpointHandlerFactory::class,
+                OAuth2Adapter::class           => OAuth2AdapterFactory::class,
+                AuthorizationServer::class     => AuthorizationServerFactory::class,
+                ResourceServer::class          => ResourceServerFactory::class,
                 // Pdo adapter
-                Pdo\PdoService::class => Pdo\PdoServiceFactory::class,
-                Pdo\AccessTokenRepository::class => Pdo\AccessTokenRepositoryFactory::class,
-                Pdo\AuthCodeRepository::class => Pdo\AuthCodeRepositoryFactory::class,
-                Pdo\ClientRepository::class => Pdo\ClientRepositoryFactory::class,
+                Pdo\PdoService::class             => Pdo\PdoServiceFactory::class,
+                Pdo\AccessTokenRepository::class  => Pdo\AccessTokenRepositoryFactory::class,
+                Pdo\AuthCodeRepository::class     => Pdo\AuthCodeRepositoryFactory::class,
+                Pdo\ClientRepository::class       => Pdo\ClientRepositoryFactory::class,
                 Pdo\RefreshTokenRepository::class => Pdo\RefreshTokenRepositoryFactory::class,
-                Pdo\ScopeRepository::class => Pdo\ScopeRepositoryFactory::class,
-                Pdo\UserRepository::class => Pdo\UserRepositoryFactory::class,
+                Pdo\ScopeRepository::class        => Pdo\ScopeRepositoryFactory::class,
+                Pdo\UserRepository::class         => Pdo\UserRepositoryFactory::class,
                 // Default Grants
                 ClientCredentialsGrant::class => ClientCredentialsGrantFactory::class,
-                PasswordGrant::class => PasswordGrantFactory::class,
-                AuthCodeGrant::class => AuthCodeGrantFactory::class,
-                ImplicitGrant::class => ImplicitGrantFactory::class,
-                RefreshTokenGrant::class => RefreshTokenGrantFactory::class,
-            ]
+                PasswordGrant::class          => PasswordGrantFactory::class,
+                AuthCodeGrant::class          => AuthCodeGrantFactory::class,
+                ImplicitGrant::class          => ImplicitGrantFactory::class,
+                RefreshTokenGrant::class      => RefreshTokenGrantFactory::class,
+            ],
         ];
     }
 
-    public function getRoutes() : array
+    public function getRoutes(): array
     {
         return [
             [
                 'name'            => 'oauth',
                 'path'            => '/oauth',
                 'middleware'      => AuthorizationMiddleware::class,
-                'allowed_methods' => ['GET', 'POST']
+                'allowed_methods' => ['GET', 'POST'],
             ],
         ];
     }

--- a/src/ConfigTrait.php
+++ b/src/ConfigTrait.php
@@ -15,7 +15,7 @@ use function is_array;
 
 trait ConfigTrait
 {
-    protected function getPrivateKey(ContainerInterface $container)
+    protected function getPrivateKey(ContainerInterface $container): string
     {
         $config = $container->get('config')['authentication'] ?? [];
 

--- a/src/ConfigTrait.php
+++ b/src/ConfigTrait.php
@@ -2,22 +2,16 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2;
 
-use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
-use League\OAuth2\Server\Repositories\AuthCodeRepositoryInterface;
-use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
-use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
-use League\OAuth2\Server\Repositories\ScopeRepositoryInterface;
-use League\OAuth2\Server\Repositories\UserRepositoryInterface;
 use Mezzio\Authentication\OAuth2\Exception\InvalidConfigException;
 use Psr\Container\ContainerInterface;
+
+use function is_array;
 
 trait ConfigTrait
 {
@@ -34,7 +28,7 @@ trait ConfigTrait
         return $config['private_key'];
     }
 
-    protected function getEncryptionKey(ContainerInterface $container) : string
+    protected function getEncryptionKey(ContainerInterface $container): string
     {
         $config = $container->get('config')['authentication'] ?? [];
 
@@ -47,7 +41,7 @@ trait ConfigTrait
         return $config['encryption_key'];
     }
 
-    protected function getAccessTokenExpire(ContainerInterface $container) : string
+    protected function getAccessTokenExpire(ContainerInterface $container): string
     {
         $config = $container->get('config')['authentication'] ?? [];
 
@@ -60,7 +54,7 @@ trait ConfigTrait
         return $config['access_token_expire'];
     }
 
-    protected function getRefreshTokenExpire(ContainerInterface $container) : string
+    protected function getRefreshTokenExpire(ContainerInterface $container): string
     {
         $config = $container->get('config')['authentication'] ?? [];
 
@@ -73,12 +67,12 @@ trait ConfigTrait
         return $config['refresh_token_expire'];
     }
 
-    protected function getAuthCodeExpire(ContainerInterface $container) : string
+    protected function getAuthCodeExpire(ContainerInterface $container): string
     {
         $config = $container->get('config')['authentication'] ?? [];
 
         if (! isset($config['auth_code_expire'])) {
-            throw new Exception\InvalidConfigException(
+            throw new InvalidConfigException(
                 'The auth_code_expire value is missing in config authentication'
             );
         }
@@ -86,7 +80,7 @@ trait ConfigTrait
         return $config['auth_code_expire'];
     }
 
-    protected function getGrantsConfig(ContainerInterface $container) : array
+    protected function getGrantsConfig(ContainerInterface $container): array
     {
         $config = $container->get('config')['authentication'] ?? [];
 
@@ -105,11 +99,9 @@ trait ConfigTrait
     }
 
     /**
-     * @param ContainerInterface $container
-     *
      * @return array
      */
-    protected function getListenersConfig(ContainerInterface $container) : array
+    protected function getListenersConfig(ContainerInterface $container): array
     {
         $config = $container->get('config')['authentication'] ?? [];
 
@@ -126,11 +118,9 @@ trait ConfigTrait
     }
 
     /**
-     * @param ContainerInterface $container
-     *
      * @return array
      */
-    protected function getListenerProvidersConfig(ContainerInterface $container) : array
+    protected function getListenerProvidersConfig(ContainerInterface $container): array
     {
         $config = $container->get('config')['authentication'] ?? [];
 

--- a/src/ConfigTrait.php
+++ b/src/ConfigTrait.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2;

--- a/src/CryptKeyTrait.php
+++ b/src/CryptKeyTrait.php
@@ -2,10 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 namespace Mezzio\Authentication\OAuth2;
 
 use League\OAuth2\Server\CryptKey;

--- a/src/CryptKeyTrait.php
+++ b/src/CryptKeyTrait.php
@@ -1,9 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 namespace Mezzio\Authentication\OAuth2;
@@ -15,7 +15,7 @@ use function sprintf;
 
 trait CryptKeyTrait
 {
-    protected function getCryptKey($keyConfig, string $configPath) : CryptKey
+    protected function getCryptKey($keyConfig, string $configPath): CryptKey
     {
         if (is_string($keyConfig)) {
             return new CryptKey($keyConfig);

--- a/src/CryptKeyTrait.php
+++ b/src/CryptKeyTrait.php
@@ -15,6 +15,9 @@ use function sprintf;
 
 trait CryptKeyTrait
 {
+    /**
+     * @param array|string $keyConfig
+     */
     protected function getCryptKey($keyConfig, string $configPath): CryptKey
     {
         if (is_string($keyConfig)) {

--- a/src/Entity/AccessTokenEntity.php
+++ b/src/Entity/AccessTokenEntity.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -17,5 +15,9 @@ use League\OAuth2\Server\Entities\Traits\TokenEntityTrait;
 
 class AccessTokenEntity implements AccessTokenEntityInterface
 {
-    use AccessTokenTrait, TokenEntityTrait, EntityTrait, RevokableTrait, TimestampableTrait;
+    use AccessTokenTrait;
+    use EntityTrait;
+    use RevokableTrait;
+    use TimestampableTrait;
+    use TokenEntityTrait;
 }

--- a/src/Entity/AccessTokenEntity.php
+++ b/src/Entity/AccessTokenEntity.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Entity;

--- a/src/Entity/AuthCodeEntity.php
+++ b/src/Entity/AuthCodeEntity.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Entity;

--- a/src/Entity/AuthCodeEntity.php
+++ b/src/Entity/AuthCodeEntity.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -17,5 +15,8 @@ use League\OAuth2\Server\Entities\Traits\TokenEntityTrait;
 
 class AuthCodeEntity implements AuthCodeEntityInterface
 {
-    use AuthCodeTrait, EntityTrait, TokenEntityTrait, RevokableTrait;
+    use AuthCodeTrait;
+    use EntityTrait;
+    use RevokableTrait;
+    use TokenEntityTrait;
 }

--- a/src/Entity/ClientEntity.php
+++ b/src/Entity/ClientEntity.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Entity;

--- a/src/Entity/ClientEntity.php
+++ b/src/Entity/ClientEntity.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -18,38 +16,30 @@ use function explode;
 
 class ClientEntity implements ClientEntityInterface
 {
-    use ClientTrait, EntityTrait, RevokableTrait, TimestampableTrait;
+    use ClientTrait;
+    use EntityTrait;
+    use RevokableTrait;
+    use TimestampableTrait;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $secret;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $personalAccessClient;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $passwordClient;
-
 
     /**
      * Constructor
      *
-     * @param string $identifier
-     * @param string $name
-     * @param string $redirectUri
-     * @param bool   $isConfidential
      * @return void
      */
     public function __construct(string $identifier, string $name, string $redirectUri, bool $isConfidential = false)
     {
         $this->setIdentifier($identifier);
-        $this->name = $name;
-        $this->redirectUri = explode(',', $redirectUri);
+        $this->name           = $name;
+        $this->redirectUri    = explode(',', $redirectUri);
         $this->isConfidential = $isConfidential;
     }
 

--- a/src/Entity/RefreshTokenEntity.php
+++ b/src/Entity/RefreshTokenEntity.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Entity;

--- a/src/Entity/RefreshTokenEntity.php
+++ b/src/Entity/RefreshTokenEntity.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -16,5 +14,7 @@ use League\OAuth2\Server\Entities\Traits\RefreshTokenTrait;
 
 class RefreshTokenEntity implements RefreshTokenEntityInterface
 {
-    use EntityTrait, RefreshTokenTrait, RevokableTrait;
+    use EntityTrait;
+    use RefreshTokenTrait;
+    use RevokableTrait;
 }

--- a/src/Entity/RevokableTrait.php
+++ b/src/Entity/RevokableTrait.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Entity;

--- a/src/Entity/RevokableTrait.php
+++ b/src/Entity/RevokableTrait.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -12,22 +10,14 @@ namespace Mezzio\Authentication\OAuth2\Entity;
 
 trait RevokableTrait
 {
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $revoked;
 
-    /**
-     * @return bool
-     */
     public function isRevoked(): bool
     {
         return $this->revoked;
     }
 
-    /**
-     * @param bool $revoked
-     */
     public function setRevoked(bool $revoked): void
     {
         $this->revoked = $revoked;

--- a/src/Entity/ScopeEntity.php
+++ b/src/Entity/ScopeEntity.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/src/Entity/ScopeEntity.php
+++ b/src/Entity/ScopeEntity.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Entity;

--- a/src/Entity/ScopeEntity.php
+++ b/src/Entity/ScopeEntity.php
@@ -16,6 +16,9 @@ class ScopeEntity implements ScopeEntityInterface
 {
     use EntityTrait;
 
+    /**
+     * @return mixed
+     */
     #[ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/src/Entity/TimestampableTrait.php
+++ b/src/Entity/TimestampableTrait.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Entity;

--- a/src/Entity/TimestampableTrait.php
+++ b/src/Entity/TimestampableTrait.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -18,32 +16,28 @@ use function method_exists;
 
 trait TimestampableTrait
 {
-    /**
-     * @var DateTime
-     */
+    /** @var DateTime */
     protected $createdAt;
 
-    /**
-     * @var DateTime
-     */
+    /** @var DateTime */
     protected $updatedAt;
 
-    public function getCreatedAt() : DateTimeInterface
+    public function getCreatedAt(): DateTimeInterface
     {
         return $this->createdAt;
     }
 
-    public function setCreatedAt(DateTimeInterface $createdAt) : void
+    public function setCreatedAt(DateTimeInterface $createdAt): void
     {
         $this->createdAt = $createdAt;
     }
 
-    public function getUpdatedAt() : DateTimeInterface
+    public function getUpdatedAt(): DateTimeInterface
     {
         return $this->updatedAt;
     }
 
-    public function setUpdatedAt(DateTimeInterface $updatedAt) : void
+    public function setUpdatedAt(DateTimeInterface $updatedAt): void
     {
         $this->updatedAt = $updatedAt;
     }
@@ -52,7 +46,7 @@ trait TimestampableTrait
      * Set createdAt on current date/time if not set, using
      * timezone if defined
      */
-    public function timestampOnCreate() : void
+    public function timestampOnCreate(): void
     {
         if (! $this->createdAt) {
             if (method_exists($this, 'getTimezone')) {

--- a/src/Entity/UserEntity.php
+++ b/src/Entity/UserEntity.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/src/Entity/UserEntity.php
+++ b/src/Entity/UserEntity.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Entity;

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Exception;

--- a/src/Exception/InvalidConfigException.php
+++ b/src/Exception/InvalidConfigException.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/src/Exception/InvalidConfigException.php
+++ b/src/Exception/InvalidConfigException.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Exception;

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Exception;

--- a/src/Grant/AuthCodeGrantFactory.php
+++ b/src/Grant/AuthCodeGrantFactory.php
@@ -19,7 +19,7 @@ class AuthCodeGrantFactory
     use ConfigTrait;
     use RepositoryTrait;
 
-    public function __invoke(ContainerInterface $container)
+    public function __invoke(ContainerInterface $container): AuthCodeGrant
     {
         $grant = new AuthCodeGrant(
             $this->getAuthCodeRepository($container),

--- a/src/Grant/AuthCodeGrantFactory.php
+++ b/src/Grant/AuthCodeGrantFactory.php
@@ -2,14 +2,13 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Grant;
 
+use DateInterval;
 use League\OAuth2\Server\Grant\AuthCodeGrant;
 use Mezzio\Authentication\OAuth2\ConfigTrait;
 use Mezzio\Authentication\OAuth2\RepositoryTrait;
@@ -17,20 +16,19 @@ use Psr\Container\ContainerInterface;
 
 class AuthCodeGrantFactory
 {
-    use RepositoryTrait;
-
     use ConfigTrait;
+    use RepositoryTrait;
 
     public function __invoke(ContainerInterface $container)
     {
         $grant = new AuthCodeGrant(
             $this->getAuthCodeRepository($container),
             $this->getRefreshTokenRepository($container),
-            new \DateInterval($this->getAuthCodeExpire($container))
+            new DateInterval($this->getAuthCodeExpire($container))
         );
 
         $grant->setRefreshTokenTTL(
-            new \DateInterval($this->getRefreshTokenExpire($container))
+            new DateInterval($this->getRefreshTokenExpire($container))
         );
 
         return $grant;

--- a/src/Grant/AuthCodeGrantFactory.php
+++ b/src/Grant/AuthCodeGrantFactory.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Grant;

--- a/src/Grant/ClientCredentialsGrantFactory.php
+++ b/src/Grant/ClientCredentialsGrantFactory.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/src/Grant/ClientCredentialsGrantFactory.php
+++ b/src/Grant/ClientCredentialsGrantFactory.php
@@ -13,7 +13,7 @@ use Psr\Container\ContainerInterface;
 
 class ClientCredentialsGrantFactory
 {
-    public function __invoke(ContainerInterface $container)
+    public function __invoke(ContainerInterface $container): ClientCredentialsGrant
     {
         return new ClientCredentialsGrant();
     }

--- a/src/Grant/ClientCredentialsGrantFactory.php
+++ b/src/Grant/ClientCredentialsGrantFactory.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Grant;

--- a/src/Grant/ImplicitGrantFactory.php
+++ b/src/Grant/ImplicitGrantFactory.php
@@ -2,14 +2,13 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Grant;
 
+use DateInterval;
 use League\OAuth2\Server\Grant\ImplicitGrant;
 use Mezzio\Authentication\OAuth2\ConfigTrait;
 use Psr\Container\ContainerInterface;
@@ -21,7 +20,7 @@ class ImplicitGrantFactory
     public function __invoke(ContainerInterface $container)
     {
         return new ImplicitGrant(
-            new \DateInterval($this->getAuthCodeExpire($container))
+            new DateInterval($this->getAuthCodeExpire($container))
         );
     }
 }

--- a/src/Grant/ImplicitGrantFactory.php
+++ b/src/Grant/ImplicitGrantFactory.php
@@ -17,7 +17,7 @@ class ImplicitGrantFactory
 {
     use ConfigTrait;
 
-    public function __invoke(ContainerInterface $container)
+    public function __invoke(ContainerInterface $container): ImplicitGrant
     {
         return new ImplicitGrant(
             new DateInterval($this->getAuthCodeExpire($container))

--- a/src/Grant/ImplicitGrantFactory.php
+++ b/src/Grant/ImplicitGrantFactory.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Grant;

--- a/src/Grant/PasswordGrantFactory.php
+++ b/src/Grant/PasswordGrantFactory.php
@@ -2,14 +2,13 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Grant;
 
+use DateInterval;
 use League\OAuth2\Server\Grant\PasswordGrant;
 use Mezzio\Authentication\OAuth2\ConfigTrait;
 use Mezzio\Authentication\OAuth2\RepositoryTrait;
@@ -17,9 +16,8 @@ use Psr\Container\ContainerInterface;
 
 class PasswordGrantFactory
 {
-    use RepositoryTrait;
-
     use ConfigTrait;
+    use RepositoryTrait;
 
     public function __invoke(ContainerInterface $container)
     {
@@ -29,7 +27,7 @@ class PasswordGrantFactory
         );
 
         $grant->setRefreshTokenTTL(
-            new \DateInterval($this->getRefreshTokenExpire($container))
+            new DateInterval($this->getRefreshTokenExpire($container))
         );
 
         return $grant;

--- a/src/Grant/PasswordGrantFactory.php
+++ b/src/Grant/PasswordGrantFactory.php
@@ -19,7 +19,7 @@ class PasswordGrantFactory
     use ConfigTrait;
     use RepositoryTrait;
 
-    public function __invoke(ContainerInterface $container)
+    public function __invoke(ContainerInterface $container): PasswordGrant
     {
         $grant = new PasswordGrant(
             $this->getUserRepository($container),

--- a/src/Grant/PasswordGrantFactory.php
+++ b/src/Grant/PasswordGrantFactory.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Grant;

--- a/src/Grant/RefreshTokenGrantFactory.php
+++ b/src/Grant/RefreshTokenGrantFactory.php
@@ -2,14 +2,13 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Grant;
 
+use DateInterval;
 use League\OAuth2\Server\Grant\RefreshTokenGrant;
 use Mezzio\Authentication\OAuth2\ConfigTrait;
 use Mezzio\Authentication\OAuth2\RepositoryTrait;
@@ -28,7 +27,7 @@ class RefreshTokenGrantFactory
         );
 
         $grant->setRefreshTokenTTL(
-            new \DateInterval($this->getRefreshTokenExpire($container))
+            new DateInterval($this->getRefreshTokenExpire($container))
         );
 
         return $grant;

--- a/src/Grant/RefreshTokenGrantFactory.php
+++ b/src/Grant/RefreshTokenGrantFactory.php
@@ -20,7 +20,7 @@ class RefreshTokenGrantFactory
 
     use RepositoryTrait;
 
-    public function __invoke(ContainerInterface $container)
+    public function __invoke(ContainerInterface $container): RefreshTokenGrant
     {
         $grant = new RefreshTokenGrant(
             $this->getRefreshTokenRepository($container)

--- a/src/Grant/RefreshTokenGrantFactory.php
+++ b/src/Grant/RefreshTokenGrantFactory.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Grant;

--- a/src/OAuth2Adapter.php
+++ b/src/OAuth2Adapter.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -19,19 +17,13 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class OAuth2Adapter implements AuthenticationInterface
 {
-    /**
-     * @var ResourceServer
-     */
+    /** @var ResourceServer */
     protected $resourceServer;
 
-    /**
-     * @var callable
-     */
+    /** @var callable */
     protected $responseFactory;
 
-    /**
-     * @var callable
-     */
+    /** @var callable */
     protected $userFactory;
 
     public function __construct(
@@ -39,15 +31,15 @@ class OAuth2Adapter implements AuthenticationInterface
         callable $responseFactory,
         callable $userFactory
     ) {
-        $this->resourceServer = $resourceServer;
-        $this->responseFactory = function () use ($responseFactory) : ResponseInterface {
+        $this->resourceServer  = $resourceServer;
+        $this->responseFactory = function () use ($responseFactory): ResponseInterface {
             return $responseFactory();
         };
-        $this->userFactory = function (
+        $this->userFactory     = function (
             string $identity,
             array $roles = [],
             array $details = []
-        ) use ($userFactory) : UserInterface {
+        ) use ($userFactory): UserInterface {
             return $userFactory($identity, $roles, $details);
         };
     }
@@ -55,21 +47,21 @@ class OAuth2Adapter implements AuthenticationInterface
     /**
      * {@inheritDoc}
      */
-    public function authenticate(ServerRequestInterface $request) : ?UserInterface
+    public function authenticate(ServerRequestInterface $request): ?UserInterface
     {
         try {
-            $result = $this->resourceServer->validateAuthenticatedRequest($request);
-            $userId = $result->getAttribute('oauth_user_id', null);
+            $result   = $this->resourceServer->validateAuthenticatedRequest($request);
+            $userId   = $result->getAttribute('oauth_user_id', null);
             $clientId = $result->getAttribute('oauth_client_id', null);
             if (isset($userId)) {
                 return ($this->userFactory)(
                     $userId,
                     [],
                     [
-                        'oauth_user_id' => $userId,
-                        'oauth_client_id' => $clientId,
+                        'oauth_user_id'         => $userId,
+                        'oauth_client_id'       => $clientId,
                         'oauth_access_token_id' => $result->getAttribute('oauth_access_token_id', null),
-                        'oauth_scopes' => $result->getAttribute('oauth_scopes', null)
+                        'oauth_scopes'          => $result->getAttribute('oauth_scopes', null),
                     ]
                 );
             }
@@ -82,7 +74,7 @@ class OAuth2Adapter implements AuthenticationInterface
     /**
      * {@inheritDoc}
      */
-    public function unauthorizedResponse(ServerRequestInterface $request) : ResponseInterface
+    public function unauthorizedResponse(ServerRequestInterface $request): ResponseInterface
     {
         return ($this->responseFactory)()
             ->withHeader(

--- a/src/OAuth2Adapter.php
+++ b/src/OAuth2Adapter.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2;

--- a/src/OAuth2AdapterFactory.php
+++ b/src/OAuth2AdapterFactory.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -17,7 +15,7 @@ use Psr\Http\Message\ResponseInterface;
 
 class OAuth2AdapterFactory
 {
-    public function __invoke(ContainerInterface $container) : OAuth2Adapter
+    public function __invoke(ContainerInterface $container): OAuth2Adapter
     {
         $resourceServer = $container->has(ResourceServer::class)
             ? $container->get(ResourceServer::class)

--- a/src/OAuth2AdapterFactory.php
+++ b/src/OAuth2AdapterFactory.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2;

--- a/src/Repository/Pdo/AbstractRepository.php
+++ b/src/Repository/Pdo/AbstractRepository.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Repository\Pdo;

--- a/src/Repository/Pdo/AbstractRepository.php
+++ b/src/Repository/Pdo/AbstractRepository.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -11,22 +9,20 @@ declare(strict_types=1);
 namespace Mezzio\Authentication\OAuth2\Repository\Pdo;
 
 use League\OAuth2\Server\Entities\ScopeEntityInterface;
+use PDO;
+
 use function array_reduce;
 use function trim;
 
 class AbstractRepository
 {
-    /**
-     * @var PdoService
-     */
+    /** @var PdoService */
     protected $pdo;
 
     /**
      * Constructor
-     *
-     * @param \PDO $pdo
      */
-    public function __construct(\PDO $pdo)
+    public function __construct(PDO $pdo)
     {
         $this->pdo = $pdo;
     }
@@ -36,9 +32,8 @@ class AbstractRepository
      * from ScopeEntityInterface[]
      *
      * @param ScopeEntityInterface[] $scopes
-     * @return string
      */
-    protected function scopesToString(array $scopes) : string
+    protected function scopesToString(array $scopes): string
     {
         if (empty($scopes)) {
             return '';

--- a/src/Repository/Pdo/AccessTokenRepository.php
+++ b/src/Repository/Pdo/AccessTokenRepository.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -18,7 +16,9 @@ use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
 use Mezzio\Authentication\OAuth2\Entity\AccessTokenEntity;
 
 use function array_key_exists;
+use function date;
 use function implode;
+use function is_array;
 use function sprintf;
 
 class AccessTokenRepository extends AbstractRepository implements AccessTokenRepositoryInterface

--- a/src/Repository/Pdo/AccessTokenRepository.php
+++ b/src/Repository/Pdo/AccessTokenRepository.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Repository\Pdo;

--- a/src/Repository/Pdo/AccessTokenRepositoryFactory.php
+++ b/src/Repository/Pdo/AccessTokenRepositoryFactory.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Repository\Pdo;

--- a/src/Repository/Pdo/AccessTokenRepositoryFactory.php
+++ b/src/Repository/Pdo/AccessTokenRepositoryFactory.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -14,7 +12,7 @@ use Psr\Container\ContainerInterface;
 
 class AccessTokenRepositoryFactory
 {
-    public function __invoke(ContainerInterface $container) : AccessTokenRepository
+    public function __invoke(ContainerInterface $container): AccessTokenRepository
     {
         return new AccessTokenRepository(
             $container->get(PdoService::class)

--- a/src/Repository/Pdo/AuthCodeRepository.php
+++ b/src/Repository/Pdo/AuthCodeRepository.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Repository\Pdo;

--- a/src/Repository/Pdo/AuthCodeRepository.php
+++ b/src/Repository/Pdo/AuthCodeRepository.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -15,6 +13,8 @@ use League\OAuth2\Server\Exception\UniqueTokenIdentifierConstraintViolationExcep
 use League\OAuth2\Server\Repositories\AuthCodeRepositoryInterface;
 use Mezzio\Authentication\OAuth2\Entity\AuthCodeEntity;
 
+use function date;
+
 class AuthCodeRepository extends AbstractRepository implements AuthCodeRepositoryInterface
 {
     /**
@@ -22,7 +22,7 @@ class AuthCodeRepository extends AbstractRepository implements AuthCodeRepositor
      */
     public function getNewAuthCode()
     {
-        return new AuthCodeEntity;
+        return new AuthCodeEntity();
     }
 
     /**
@@ -31,8 +31,8 @@ class AuthCodeRepository extends AbstractRepository implements AuthCodeRepositor
     public function persistNewAuthCode(AuthCodeEntityInterface $authCodeEntity)
     {
         $sth = $this->pdo->prepare(
-            'INSERT INTO oauth_auth_codes (id, user_id, client_id, scopes, revoked, expires_at) ' .
-            'VALUES (:id, :user_id, :client_id, :scopes, :revoked, :expires_at)'
+            'INSERT INTO oauth_auth_codes (id, user_id, client_id, scopes, revoked, expires_at) '
+            . 'VALUES (:id, :user_id, :client_id, :scopes, :revoked, :expires_at)'
         );
 
         $sth->bindValue(':id', $authCodeEntity->getIdentifier());

--- a/src/Repository/Pdo/AuthCodeRepositoryFactory.php
+++ b/src/Repository/Pdo/AuthCodeRepositoryFactory.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -14,7 +12,7 @@ use Psr\Container\ContainerInterface;
 
 class AuthCodeRepositoryFactory
 {
-    public function __invoke(ContainerInterface $container) : AuthCodeRepository
+    public function __invoke(ContainerInterface $container): AuthCodeRepository
     {
         return new AuthCodeRepository(
             $container->get(PdoService::class)

--- a/src/Repository/Pdo/AuthCodeRepositoryFactory.php
+++ b/src/Repository/Pdo/AuthCodeRepositoryFactory.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Repository\Pdo;

--- a/src/Repository/Pdo/ClientRepository.php
+++ b/src/Repository/Pdo/ClientRepository.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Repository\Pdo;

--- a/src/Repository/Pdo/ClientRepository.php
+++ b/src/Repository/Pdo/ClientRepository.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -21,7 +19,7 @@ class ClientRepository extends AbstractRepository implements ClientRepositoryInt
     /**
      * {@inheritDoc}
      */
-    public function getClientEntity($clientIdentifier) : ?ClientEntityInterface
+    public function getClientEntity($clientIdentifier): ?ClientEntityInterface
     {
         $clientData = $this->getClientData($clientIdentifier);
 
@@ -40,7 +38,7 @@ class ClientRepository extends AbstractRepository implements ClientRepositoryInt
     /**
      * {@inheritDoc}
      */
-    public function validateClient($clientIdentifier, $clientSecret, $grantType) : bool
+    public function validateClient($clientIdentifier, $clientSecret, $grantType): bool
     {
         $clientData = $this->getClientData($clientIdentifier);
 
@@ -63,11 +61,8 @@ class ClientRepository extends AbstractRepository implements ClientRepositoryInt
      * Check the grantType for the client value, stored in $row
      *
      * @param array  $row
-     * @param string $grantType
-     *
-     * @return bool
      */
-    protected function isGranted(array $row, string $grantType = null) : bool
+    protected function isGranted(array $row, ?string $grantType = null): bool
     {
         switch ($grantType) {
             case 'authorization_code':
@@ -81,7 +76,7 @@ class ClientRepository extends AbstractRepository implements ClientRepositoryInt
         }
     }
 
-    private function getClientData(string $clientIdentifier) : ?array
+    private function getClientData(string $clientIdentifier): ?array
     {
         $statement = $this->pdo->prepare(
             'SELECT * FROM oauth_clients WHERE name = :clientIdentifier'

--- a/src/Repository/Pdo/ClientRepositoryFactory.php
+++ b/src/Repository/Pdo/ClientRepositoryFactory.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Repository\Pdo;

--- a/src/Repository/Pdo/ClientRepositoryFactory.php
+++ b/src/Repository/Pdo/ClientRepositoryFactory.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -14,7 +12,7 @@ use Psr\Container\ContainerInterface;
 
 class ClientRepositoryFactory
 {
-    public function __invoke(ContainerInterface $container) : ClientRepository
+    public function __invoke(ContainerInterface $container): ClientRepository
     {
         return new ClientRepository(
             $container->get(PdoService::class)

--- a/src/Repository/Pdo/PdoService.php
+++ b/src/Repository/Pdo/PdoService.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/src/Repository/Pdo/PdoService.php
+++ b/src/Repository/Pdo/PdoService.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Repository\Pdo;

--- a/src/Repository/Pdo/PdoServiceFactory.php
+++ b/src/Repository/Pdo/PdoServiceFactory.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -11,11 +9,14 @@ declare(strict_types=1);
 namespace Mezzio\Authentication\OAuth2\Repository\Pdo;
 
 use Mezzio\Authentication\OAuth2\Exception;
+use PDO;
 use Psr\Container\ContainerInterface;
+
+use function is_string;
 
 class PdoServiceFactory
 {
-    public function __invoke(ContainerInterface $container) : \PDO
+    public function __invoke(ContainerInterface $container): PDO
     {
         $config = $container->has('config') ? $container->get('config') : [];
         $config = $config['authentication']['pdo'] ?? null;

--- a/src/Repository/Pdo/PdoServiceFactory.php
+++ b/src/Repository/Pdo/PdoServiceFactory.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Repository\Pdo;

--- a/src/Repository/Pdo/RefreshTokenRepository.php
+++ b/src/Repository/Pdo/RefreshTokenRepository.php
@@ -45,6 +45,9 @@ class RefreshTokenRepository extends AbstractRepository implements RefreshTokenR
         }
     }
 
+    /**
+     * @param string $tokenId
+     */
     public function revokeRefreshToken($tokenId)
     {
         $sth = $this->pdo->prepare(
@@ -56,6 +59,9 @@ class RefreshTokenRepository extends AbstractRepository implements RefreshTokenR
         $sth->execute();
     }
 
+    /**
+     * @param string $tokenId
+     */
     public function isRefreshTokenRevoked($tokenId): bool
     {
         $sth = $this->pdo->prepare(

--- a/src/Repository/Pdo/RefreshTokenRepository.php
+++ b/src/Repository/Pdo/RefreshTokenRepository.php
@@ -17,7 +17,7 @@ use function date;
 
 class RefreshTokenRepository extends AbstractRepository implements RefreshTokenRepositoryInterface
 {
-    public function getNewRefreshToken()
+    public function getNewRefreshToken(): RefreshTokenEntity
     {
         return new RefreshTokenEntity();
     }
@@ -56,7 +56,7 @@ class RefreshTokenRepository extends AbstractRepository implements RefreshTokenR
         $sth->execute();
     }
 
-    public function isRefreshTokenRevoked($tokenId)
+    public function isRefreshTokenRevoked($tokenId): bool
     {
         $sth = $this->pdo->prepare(
             'SELECT revoked FROM oauth_refresh_tokens WHERE id = :tokenId'

--- a/src/Repository/Pdo/RefreshTokenRepository.php
+++ b/src/Repository/Pdo/RefreshTokenRepository.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Repository\Pdo;

--- a/src/Repository/Pdo/RefreshTokenRepository.php
+++ b/src/Repository/Pdo/RefreshTokenRepository.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -15,18 +13,20 @@ use League\OAuth2\Server\Exception\UniqueTokenIdentifierConstraintViolationExcep
 use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
 use Mezzio\Authentication\OAuth2\Entity\RefreshTokenEntity;
 
+use function date;
+
 class RefreshTokenRepository extends AbstractRepository implements RefreshTokenRepositoryInterface
 {
     public function getNewRefreshToken()
     {
-        return new RefreshTokenEntity;
+        return new RefreshTokenEntity();
     }
 
     public function persistNewRefreshToken(RefreshTokenEntityInterface $refreshTokenEntity)
     {
         $sth = $this->pdo->prepare(
-            'INSERT INTO oauth_refresh_tokens (id, access_token_id, revoked, expires_at) ' .
-            'VALUES (:id, :access_token_id, :revoked, :expires_at)'
+            'INSERT INTO oauth_refresh_tokens (id, access_token_id, revoked, expires_at) '
+            . 'VALUES (:id, :access_token_id, :revoked, :expires_at)'
         );
 
         $sth->bindValue(':id', $refreshTokenEntity->getIdentifier());

--- a/src/Repository/Pdo/RefreshTokenRepositoryFactory.php
+++ b/src/Repository/Pdo/RefreshTokenRepositoryFactory.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Repository\Pdo;

--- a/src/Repository/Pdo/RefreshTokenRepositoryFactory.php
+++ b/src/Repository/Pdo/RefreshTokenRepositoryFactory.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -14,7 +12,7 @@ use Psr\Container\ContainerInterface;
 
 class RefreshTokenRepositoryFactory
 {
-    public function __invoke(ContainerInterface $container) : RefreshTokenRepository
+    public function __invoke(ContainerInterface $container): RefreshTokenRepository
     {
         return new RefreshTokenRepository(
             $container->get(PdoService::class)

--- a/src/Repository/Pdo/ScopeRepository.php
+++ b/src/Repository/Pdo/ScopeRepository.php
@@ -9,11 +9,16 @@ declare(strict_types=1);
 namespace Mezzio\Authentication\OAuth2\Repository\Pdo;
 
 use League\OAuth2\Server\Entities\ClientEntityInterface;
+use League\OAuth2\Server\Entities\ScopeEntityInterface;
 use League\OAuth2\Server\Repositories\ScopeRepositoryInterface;
 use Mezzio\Authentication\OAuth2\Entity\ScopeEntity;
 
 class ScopeRepository extends AbstractRepository implements ScopeRepositoryInterface
 {
+    /**
+     * @param string $identifier
+     * @return ScopeEntity|void
+     */
     public function getScopeEntityByIdentifier($identifier)
     {
         $sth = $this->pdo->prepare(
@@ -35,6 +40,12 @@ class ScopeRepository extends AbstractRepository implements ScopeRepositoryInter
         return $scope;
     }
 
+    /**
+     * @param ScopeEntityInterface[] $scopes
+     * @param string                 $grantType
+     * @param null|string            $userIdentifier
+     * @return ScopeEntityInterface[]
+     */
     public function finalizeScopes(
         array $scopes,
         $grantType,

--- a/src/Repository/Pdo/ScopeRepository.php
+++ b/src/Repository/Pdo/ScopeRepository.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/src/Repository/Pdo/ScopeRepository.php
+++ b/src/Repository/Pdo/ScopeRepository.php
@@ -40,7 +40,7 @@ class ScopeRepository extends AbstractRepository implements ScopeRepositoryInter
         $grantType,
         ClientEntityInterface $clientEntity,
         $userIdentifier = null
-    ) {
+    ): array {
         return $scopes;
     }
 }

--- a/src/Repository/Pdo/ScopeRepository.php
+++ b/src/Repository/Pdo/ScopeRepository.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Repository\Pdo;

--- a/src/Repository/Pdo/ScopeRepositoryFactory.php
+++ b/src/Repository/Pdo/ScopeRepositoryFactory.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Repository\Pdo;

--- a/src/Repository/Pdo/ScopeRepositoryFactory.php
+++ b/src/Repository/Pdo/ScopeRepositoryFactory.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -14,7 +12,7 @@ use Psr\Container\ContainerInterface;
 
 class ScopeRepositoryFactory
 {
-    public function __invoke(ContainerInterface $container) : ScopeRepository
+    public function __invoke(ContainerInterface $container): ScopeRepository
     {
         return new ScopeRepository(
             $container->get(PdoService::class)

--- a/src/Repository/Pdo/UserRepository.php
+++ b/src/Repository/Pdo/UserRepository.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/src/Repository/Pdo/UserRepository.php
+++ b/src/Repository/Pdo/UserRepository.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Repository\Pdo;

--- a/src/Repository/Pdo/UserRepository.php
+++ b/src/Repository/Pdo/UserRepository.php
@@ -16,6 +16,12 @@ use function password_verify;
 
 class UserRepository extends AbstractRepository implements UserRepositoryInterface
 {
+    /**
+     * @param string $username
+     * @param string $password
+     * @param string $grantType
+     * @return UserEntity|void
+     */
     public function getUserEntityByUserCredentials(
         $username,
         $password,

--- a/src/Repository/Pdo/UserRepository.php
+++ b/src/Repository/Pdo/UserRepository.php
@@ -42,7 +42,5 @@ class UserRepository extends AbstractRepository implements UserRepositoryInterfa
         if (! empty($row) && password_verify($password, $row['password'])) {
             return new UserEntity($username);
         }
-
-        return;
     }
 }

--- a/src/Repository/Pdo/UserRepositoryFactory.php
+++ b/src/Repository/Pdo/UserRepositoryFactory.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2\Repository\Pdo;

--- a/src/Repository/Pdo/UserRepositoryFactory.php
+++ b/src/Repository/Pdo/UserRepositoryFactory.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -14,7 +12,7 @@ use Psr\Container\ContainerInterface;
 
 class UserRepositoryFactory
 {
-    public function __invoke(ContainerInterface $container) : UserRepository
+    public function __invoke(ContainerInterface $container): UserRepository
     {
         return new UserRepository(
             $container->get(PdoService::class)

--- a/src/RepositoryTrait.php
+++ b/src/RepositoryTrait.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2;

--- a/src/RepositoryTrait.php
+++ b/src/RepositoryTrait.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -20,7 +18,7 @@ use Psr\Container\ContainerInterface;
 
 trait RepositoryTrait
 {
-    protected function getUserRepository(ContainerInterface $container) : UserRepositoryInterface
+    protected function getUserRepository(ContainerInterface $container): UserRepositoryInterface
     {
         if (! $container->has(UserRepositoryInterface::class)) {
             throw new Exception\InvalidConfigException(
@@ -30,7 +28,7 @@ trait RepositoryTrait
         return $container->get(UserRepositoryInterface::class);
     }
 
-    protected function getScopeRepository(ContainerInterface $container) : ScopeRepositoryInterface
+    protected function getScopeRepository(ContainerInterface $container): ScopeRepositoryInterface
     {
         if (! $container->has(ScopeRepositoryInterface::class)) {
             throw new Exception\InvalidConfigException(
@@ -40,7 +38,7 @@ trait RepositoryTrait
         return $container->get(ScopeRepositoryInterface::class);
     }
 
-    protected function getAccessTokenRepository(ContainerInterface $container) : AccessTokenRepositoryInterface
+    protected function getAccessTokenRepository(ContainerInterface $container): AccessTokenRepositoryInterface
     {
         if (! $container->has(AccessTokenRepositoryInterface::class)) {
             throw new Exception\InvalidConfigException(
@@ -50,7 +48,7 @@ trait RepositoryTrait
         return $container->get(AccessTokenRepositoryInterface::class);
     }
 
-    protected function getClientRepository(ContainerInterface $container) : ClientRepositoryInterface
+    protected function getClientRepository(ContainerInterface $container): ClientRepositoryInterface
     {
         if (! $container->has(ClientRepositoryInterface::class)) {
             throw new Exception\InvalidConfigException(
@@ -60,7 +58,7 @@ trait RepositoryTrait
         return $container->get(ClientRepositoryInterface::class);
     }
 
-    protected function getRefreshTokenRepository(ContainerInterface $container) : RefreshTokenRepositoryInterface
+    protected function getRefreshTokenRepository(ContainerInterface $container): RefreshTokenRepositoryInterface
     {
         if (! $container->has(RefreshTokenRepositoryInterface::class)) {
             throw new Exception\InvalidConfigException(
@@ -70,7 +68,7 @@ trait RepositoryTrait
         return $container->get(RefreshTokenRepositoryInterface::class);
     }
 
-    protected function getAuthCodeRepository(ContainerInterface $container) : AuthCodeRepositoryInterface
+    protected function getAuthCodeRepository(ContainerInterface $container): AuthCodeRepositoryInterface
     {
         if (! $container->has(AuthCodeRepositoryInterface::class)) {
             throw new Exception\InvalidConfigException(

--- a/src/ResourceServerFactory.php
+++ b/src/ResourceServerFactory.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2;

--- a/src/ResourceServerFactory.php
+++ b/src/ResourceServerFactory.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -18,7 +16,7 @@ class ResourceServerFactory
     use CryptKeyTrait;
     use RepositoryTrait;
 
-    public function __invoke(ContainerInterface $container) : ResourceServer
+    public function __invoke(ContainerInterface $container): ResourceServer
     {
         $config = $container->has('config') ? $container->get('config') : [];
         $config = $config['authentication'] ?? [];

--- a/src/TokenEndpointHandler.php
+++ b/src/TokenEndpointHandler.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -12,13 +10,9 @@ namespace Mezzio\Authentication\OAuth2;
 
 use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\Exception\OAuthServerException;
-use Mezzio\Authentication\OAuth2\Entity\UserEntity;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-
-use function strtoupper;
 
 /**
  * Provides an OAuth2 token endpoint implementation
@@ -32,19 +26,15 @@ use function strtoupper;
  */
 class TokenEndpointHandler implements RequestHandlerInterface
 {
-    /**
-     * @var AuthorizationServer
-     */
+    /** @var AuthorizationServer */
     protected $server;
 
-    /**
-     * @var callable
-     */
+    /** @var callable */
     protected $responseFactory;
 
     public function __construct(AuthorizationServer $server, callable $responseFactory)
     {
-        $this->server = $server;
+        $this->server          = $server;
         $this->responseFactory = $responseFactory;
     }
 

--- a/src/TokenEndpointHandler.php
+++ b/src/TokenEndpointHandler.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2;

--- a/src/TokenEndpointHandlerFactory.php
+++ b/src/TokenEndpointHandlerFactory.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/src/TokenEndpointHandlerFactory.php
+++ b/src/TokenEndpointHandlerFactory.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2;

--- a/test/AuthorizationHandlerFactoryTest.php
+++ b/test/AuthorizationHandlerFactoryTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2;

--- a/test/AuthorizationHandlerFactoryTest.php
+++ b/test/AuthorizationHandlerFactoryTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -39,7 +37,7 @@ class AuthorizationHandlerFactoryTest extends TestCase
     /** @var ResponseInterface|ObjectProphecy */
     private $response;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->container  = $this->prophesize(ContainerInterface::class);
         $this->authServer = $this->prophesize(AuthorizationServer::class);
@@ -109,7 +107,7 @@ class AuthorizationHandlerFactoryTest extends TestCase
                 return $this->response->reveal();
             });
 
-        $factory = new AuthorizationHandlerFactory();
+        $factory    = new AuthorizationHandlerFactory();
         $middleware = $factory($this->container->reveal());
         $this->assertInstanceOf(AuthorizationHandler::class, $middleware);
     }

--- a/test/AuthorizationHandlerTest.php
+++ b/test/AuthorizationHandlerTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -29,10 +27,10 @@ class AuthorizationHandlerTest extends TestCase
 
     public function testHandleUsesAuthorizationServerService(): void
     {
-        $server = $this->prophesize(AuthorizationServer::class);
-        $response = $this->prophesize(ResponseInterface::class);
-        $authRequest = $this->prophesize(AuthorizationRequest::class);
-        $request = $this->prophesize(ServerRequestInterface::class);
+        $server           = $this->prophesize(AuthorizationServer::class);
+        $response         = $this->prophesize(ResponseInterface::class);
+        $authRequest      = $this->prophesize(AuthorizationRequest::class);
+        $request          = $this->prophesize(ServerRequestInterface::class);
         $expectedResponse = $response->reveal();
 
         $request->getAttribute(AuthorizationRequest::class)
@@ -51,9 +49,9 @@ class AuthorizationHandlerTest extends TestCase
 
     public function testInvalidResponseFactoryThrowsTypeError()
     {
-        $server = $this->prophesize(AuthorizationServer::class);
+        $server      = $this->prophesize(AuthorizationServer::class);
         $authRequest = $this->prophesize(AuthorizationRequest::class);
-        $request = $this->prophesize(ServerRequestInterface::class);
+        $request     = $this->prophesize(ServerRequestInterface::class);
 
         $request->getAttribute(AuthorizationRequest::class)
             ->willReturn($authRequest->reveal());

--- a/test/AuthorizationHandlerTest.php
+++ b/test/AuthorizationHandlerTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace Mezzio\Authentication\OAuth2;

--- a/test/AuthorizationMiddlewareFactoryTest.php
+++ b/test/AuthorizationMiddlewareFactoryTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2;

--- a/test/AuthorizationMiddlewareFactoryTest.php
+++ b/test/AuthorizationMiddlewareFactoryTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -37,7 +35,7 @@ class AuthorizationMiddlewareFactoryTest extends TestCase
     /** @var ResponseInterface|ObjectProphecy */
     private $response;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->container  = $this->prophesize(ContainerInterface::class);
         $this->authServer = $this->prophesize(AuthorizationServer::class);
@@ -107,7 +105,7 @@ class AuthorizationMiddlewareFactoryTest extends TestCase
                 return $this->response->reveal();
             });
 
-        $factory = new AuthorizationMiddlewareFactory();
+        $factory    = new AuthorizationMiddlewareFactory();
         $middleware = $factory($this->container->reveal());
         $this->assertInstanceOf(AuthorizationMiddleware::class, $middleware);
     }

--- a/test/AuthorizationMiddlewareTest.php
+++ b/test/AuthorizationMiddlewareTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2;

--- a/test/AuthorizationMiddlewareTest.php
+++ b/test/AuthorizationMiddlewareTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -47,7 +45,7 @@ class AuthorizationMiddlewareTest extends TestCase
     /** @var ServerRequestInterface|ObjectProphecy */
     private $serverRequest;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->authServer      = $this->prophesize(AuthorizationServer::class);
         $this->response        = $this->prophesize(ResponseInterface::class);
@@ -98,12 +96,11 @@ class AuthorizationMiddlewareTest extends TestCase
             ->handle($newRequest->reveal())
             ->willReturn($handlerResponse);
 
-
         $middleware = new AuthorizationMiddleware(
             $this->authServer->reveal(),
             $this->responseFactory
         );
-        $response = $middleware->process(
+        $response   = $middleware->process(
             $this->serverRequest->reveal(),
             $this->handler->reveal()
         );
@@ -113,7 +110,7 @@ class AuthorizationMiddlewareTest extends TestCase
 
     public function testAuthorizationRequestRaisingOAuthServerExceptionGeneratesResponseFromException()
     {
-        $response = $this->prophesize(ResponseInterface::class);
+        $response             = $this->prophesize(ResponseInterface::class);
         $oauthServerException = $this->prophesize(OAuthServerException::class);
         $oauthServerException
             ->generateHttpResponse(Argument::type(ResponseInterface::class))

--- a/test/AuthorizationServerFactoryTest.php
+++ b/test/AuthorizationServerFactoryTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2;

--- a/test/AuthorizationServerFactoryTest.php
+++ b/test/AuthorizationServerFactoryTest.php
@@ -8,7 +8,6 @@ use League\Event\ListenerInterface;
 use League\Event\ListenerProviderInterface;
 use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\Grant\ClientCredentialsGrant;
-use League\OAuth2\Server\Grant\GrantTypeInterface;
 use League\OAuth2\Server\Grant\PasswordGrant;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
 use League\OAuth2\Server\Repositories\ClientRepositoryInterface;

--- a/test/AuthorizationServerFactoryTest.php
+++ b/test/AuthorizationServerFactoryTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -27,33 +25,29 @@ use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 
-use function array_merge;
-use function array_slice;
-use function in_array;
-
 class AuthorizationServerFactoryTest extends TestCase
 {
     use ProphecyTrait;
 
     public function testInvoke()
     {
-        $mockContainer = $this->prophesize(ContainerInterface::class);
-        $mockClientRepo = $this->prophesize(ClientRepositoryInterface::class);
+        $mockContainer       = $this->prophesize(ContainerInterface::class);
+        $mockClientRepo      = $this->prophesize(ClientRepositoryInterface::class);
         $mockAccessTokenRepo = $this->prophesize(AccessTokenRepositoryInterface::class);
-        $mockScopeRepo = $this->prophesize(ScopeRepositoryInterface::class);
-        $mockClientGrant = $this->prophesize(ClientCredentialsGrant::class);
-        $mockPasswordGrant = $this->prophesize(PasswordGrant::class);
+        $mockScopeRepo       = $this->prophesize(ScopeRepositoryInterface::class);
+        $mockClientGrant     = $this->prophesize(ClientCredentialsGrant::class);
+        $mockPasswordGrant   = $this->prophesize(PasswordGrant::class);
 
         $config = [
             'authentication' => [
-                'private_key' => __DIR__ . '/TestAsset/private.key',
-                'encryption_key' => 'iALlwJ1sH77dmFCJFo+pMdM6Af4bF/hCca1EDDx7MwE=',
+                'private_key'         => __DIR__ . '/TestAsset/private.key',
+                'encryption_key'      => 'iALlwJ1sH77dmFCJFo+pMdM6Af4bF/hCca1EDDx7MwE=',
                 'access_token_expire' => 'P1D',
-                'grants' => [
+                'grants'              => [
                     ClientCredentialsGrant::class => ClientCredentialsGrant::class,
-                    PasswordGrant::class => PasswordGrant::class,
+                    PasswordGrant::class          => PasswordGrant::class,
                 ],
-            ]
+            ],
         ];
 
         $mockContainer->has(ClientRepositoryInterface::class)->willReturn(true);
@@ -74,17 +68,14 @@ class AuthorizationServerFactoryTest extends TestCase
         $this->assertInstanceOf(AuthorizationServer::class, $result);
     }
 
-    /**
-     * @return ObjectProphecy
-     */
     private function getContainerMock(): ObjectProphecy
     {
-        $mockContainer = $this->prophesize(ContainerInterface::class);
-        $mockClientRepo = $this->prophesize(ClientRepositoryInterface::class);
+        $mockContainer       = $this->prophesize(ContainerInterface::class);
+        $mockClientRepo      = $this->prophesize(ClientRepositoryInterface::class);
         $mockAccessTokenRepo = $this->prophesize(AccessTokenRepositoryInterface::class);
-        $mockScopeRepo = $this->prophesize(ScopeRepositoryInterface::class);
-        $mockClientGrant = $this->prophesize(ClientCredentialsGrant::class);
-        $mockPasswordGrant = $this->prophesize(PasswordGrant::class);
+        $mockScopeRepo       = $this->prophesize(ScopeRepositoryInterface::class);
+        $mockClientGrant     = $this->prophesize(ClientCredentialsGrant::class);
+        $mockPasswordGrant   = $this->prophesize(PasswordGrant::class);
 
         $mockContainer->has(ClientRepositoryInterface::class)->willReturn(true);
         $mockContainer->has(AccessTokenRepositoryInterface::class)->willReturn(true);
@@ -105,12 +96,12 @@ class AuthorizationServerFactoryTest extends TestCase
 
         $config = [
             'authentication' => [
-                'private_key' => __DIR__ . '/TestAsset/private.key',
-                'encryption_key' => 'iALlwJ1sH77dmFCJFo+pMdM6Af4bF/hCca1EDDx7MwE=',
+                'private_key'         => __DIR__ . '/TestAsset/private.key',
+                'encryption_key'      => 'iALlwJ1sH77dmFCJFo+pMdM6Af4bF/hCca1EDDx7MwE=',
                 'access_token_expire' => 'P1D',
-                'grants' => [
+                'grants'              => [
                     ClientCredentialsGrant::class => null,
-                    PasswordGrant::class => PasswordGrant::class,
+                    PasswordGrant::class          => PasswordGrant::class,
                 ],
             ],
         ];
@@ -127,19 +118,19 @@ class AuthorizationServerFactoryTest extends TestCase
     public function testInvokeWithListenerConfig()
     {
         $mockContainer = $this->getContainerMock();
-        $mockListener = $this->prophesize(ListenerInterface::class);
+        $mockListener  = $this->prophesize(ListenerInterface::class);
         $mockContainer->has(ListenerInterface::class)->willReturn(true);
         $mockContainer->get(ListenerInterface::class)->willReturn($mockListener->reveal());
 
         $config = [
             'authentication' => [
-                'private_key' => __DIR__ . '/TestAsset/private.key',
-                'encryption_key' => 'iALlwJ1sH77dmFCJFo+pMdM6Af4bF/hCca1EDDx7MwE=',
+                'private_key'         => __DIR__ . '/TestAsset/private.key',
+                'encryption_key'      => 'iALlwJ1sH77dmFCJFo+pMdM6Af4bF/hCca1EDDx7MwE=',
                 'access_token_expire' => 'P1D',
-                'grants' => [
+                'grants'              => [
                     ClientCredentialsGrant::class => ClientCredentialsGrant::class,
                 ],
-                'event_listeners' => [
+                'event_listeners'     => [
                     [
                         RequestEvent::CLIENT_AUTHENTICATION_FAILED,
                         function (RequestEvent $event) {
@@ -166,18 +157,18 @@ class AuthorizationServerFactoryTest extends TestCase
     public function testInvokeWithListenerConfigMissingServiceThrowsException()
     {
         $mockContainer = $this->getContainerMock();
-        $mockListener = $this->prophesize(ListenerInterface::class);
+        $mockListener  = $this->prophesize(ListenerInterface::class);
         $mockContainer->has(ListenerInterface::class)->willReturn(false);
 
         $config = [
             'authentication' => [
-                'private_key' => __DIR__ . '/TestAsset/private.key',
-                'encryption_key' => 'iALlwJ1sH77dmFCJFo+pMdM6Af4bF/hCca1EDDx7MwE=',
+                'private_key'         => __DIR__ . '/TestAsset/private.key',
+                'encryption_key'      => 'iALlwJ1sH77dmFCJFo+pMdM6Af4bF/hCca1EDDx7MwE=',
                 'access_token_expire' => 'P1D',
-                'grants' => [
+                'grants'              => [
                     ClientCredentialsGrant::class => ClientCredentialsGrant::class,
                 ],
-                'event_listeners' => [
+                'event_listeners'     => [
                     [
                         RequestEvent::CLIENT_AUTHENTICATION_FAILED,
                         ListenerInterface::class,
@@ -198,20 +189,20 @@ class AuthorizationServerFactoryTest extends TestCase
     public function testInvokeWithListenerProviderConfig()
     {
         $mockContainer = $this->getContainerMock();
-        $mockProvider = $this->prophesize(ListenerProviderInterface::class);
+        $mockProvider  = $this->prophesize(ListenerProviderInterface::class);
         $mockContainer->has(ListenerProviderInterface::class)->willReturn(true);
         $mockContainer->get(ListenerProviderInterface::class)->willReturn($mockProvider->reveal());
 
         $config = [
             'authentication' => [
-                'private_key' => __DIR__ . '/TestAsset/private.key',
-                'encryption_key' => 'iALlwJ1sH77dmFCJFo+pMdM6Af4bF/hCca1EDDx7MwE=',
-                'access_token_expire' => 'P1D',
-                'grants' => [
+                'private_key'              => __DIR__ . '/TestAsset/private.key',
+                'encryption_key'           => 'iALlwJ1sH77dmFCJFo+pMdM6Af4bF/hCca1EDDx7MwE=',
+                'access_token_expire'      => 'P1D',
+                'grants'                   => [
                     ClientCredentialsGrant::class => ClientCredentialsGrant::class,
                 ],
                 'event_listener_providers' => [
-                    ListenerProviderInterface::class
+                    ListenerProviderInterface::class,
                 ],
             ],
         ];
@@ -228,15 +219,15 @@ class AuthorizationServerFactoryTest extends TestCase
     public function testInvokeWithListenerProviderConfigMissingServiceThrowsException()
     {
         $mockContainer = $this->getContainerMock();
-        $mockProvider = $this->prophesize(ListenerProviderInterface::class);
+        $mockProvider  = $this->prophesize(ListenerProviderInterface::class);
         $mockContainer->has(ListenerProviderInterface::class)->willReturn(false);
 
         $config = [
             'authentication' => [
-                'private_key' => __DIR__ . '/TestAsset/private.key',
-                'encryption_key' => 'iALlwJ1sH77dmFCJFo+pMdM6Af4bF/hCca1EDDx7MwE=',
-                'access_token_expire' => 'P1D',
-                'grants' => [
+                'private_key'              => __DIR__ . '/TestAsset/private.key',
+                'encryption_key'           => 'iALlwJ1sH77dmFCJFo+pMdM6Af4bF/hCca1EDDx7MwE=',
+                'access_token_expire'      => 'P1D',
+                'grants'                   => [
                     ClientCredentialsGrant::class => ClientCredentialsGrant::class,
                 ],
                 'event_listener_providers' => [

--- a/test/ConfigTraitTest.php
+++ b/test/ConfigTraitTest.php
@@ -23,6 +23,9 @@ class ConfigTraitTest extends TestCase
         $this->trait     = $trait = new class {
             use ConfigTrait;
 
+            /**
+             * @return array|string
+             */
             public function proxy(string $name, ContainerInterface $container)
             {
                 return $this->$name($container);

--- a/test/ConfigTraitTest.php
+++ b/test/ConfigTraitTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2;

--- a/test/ConfigTraitTest.php
+++ b/test/ConfigTraitTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -20,9 +18,9 @@ class ConfigTraitTest extends TestCase
 {
     use ProphecyTrait;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
-        $this->trait = $trait = new class {
+        $this->trait     = $trait = new class {
             use ConfigTrait;
 
             public function proxy(string $name, ContainerInterface $container)
@@ -30,15 +28,15 @@ class ConfigTraitTest extends TestCase
                 return $this->$name($container);
             }
         };
-        $this->config = [
+        $this->config    = [
             'authentication' => [
-                'private_key' => 'xxx',
-                'encryption_key' => 'xxx',
-                'access_token_expire' => '3600',
+                'private_key'          => 'xxx',
+                'encryption_key'       => 'xxx',
+                'access_token_expire'  => '3600',
                 'refresh_token_expire' => '3600',
-                'auth_code_expire' => '120',
-                'grants' => ['xxx']
-            ]
+                'auth_code_expire'     => '120',
+                'grants'               => ['xxx'],
+            ],
         ];
         $this->container = $this->prophesize(ContainerInterface::class);
         $this->container
@@ -189,7 +187,7 @@ class ConfigTraitTest extends TestCase
                     'event_listeners' => $expected = [['xxx']],
                 ],
             ]);
-        $result = $this->trait
+        $result                                    = $this->trait
             ->proxy('getListenersConfig', $this->container->reveal());
         $this->assertEquals($expected, $result);
     }
@@ -227,7 +225,7 @@ class ConfigTraitTest extends TestCase
                     'event_listener_providers' => $expected = ['xxx'],
                 ],
             ]);
-        $result = $this->trait
+        $result                                             = $this->trait
             ->proxy('getListenerProvidersConfig', $this->container->reveal());
         $this->assertEquals($expected, $result);
     }

--- a/test/ConfigTraitTest.php
+++ b/test/ConfigTraitTest.php
@@ -186,7 +186,7 @@ class ConfigTraitTest extends TestCase
                     'event_listeners' => $expected = [['xxx']],
                 ],
             ]);
-        $result                                    = $this->trait
+        $result = $this->trait
             ->proxy('getListenersConfig', $this->container->reveal());
         $this->assertEquals($expected, $result);
     }
@@ -224,7 +224,7 @@ class ConfigTraitTest extends TestCase
                     'event_listener_providers' => $expected = ['xxx'],
                 ],
             ]);
-        $result                                             = $this->trait
+        $result = $this->trait
             ->proxy('getListenerProvidersConfig', $this->container->reveal());
         $this->assertEquals($expected, $result);
     }

--- a/test/Entity/AccessTokenEntityTest.php
+++ b/test/Entity/AccessTokenEntityTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/test/Entity/AccessTokenEntityTest.php
+++ b/test/Entity/AccessTokenEntityTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2\Entity;

--- a/test/Entity/AuthCodeEntityTest.php
+++ b/test/Entity/AuthCodeEntityTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/test/Entity/AuthCodeEntityTest.php
+++ b/test/Entity/AuthCodeEntityTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2\Entity;

--- a/test/Entity/ClientEntityTest.php
+++ b/test/Entity/ClientEntityTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -16,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 class ClientEntityTest extends TestCase
 {
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->entity = new ClientEntity('foo', 'bar', 'http://localhost');
     }

--- a/test/Entity/ClientEntityTest.php
+++ b/test/Entity/ClientEntityTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2\Entity;

--- a/test/Entity/RefreshTokenEntityTest.php
+++ b/test/Entity/RefreshTokenEntityTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/test/Entity/RefreshTokenEntityTest.php
+++ b/test/Entity/RefreshTokenEntityTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2\Entity;

--- a/test/Entity/RevokableTraitTest.php
+++ b/test/Entity/RevokableTraitTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2\Entity;

--- a/test/Entity/RevokableTraitTest.php
+++ b/test/Entity/RevokableTraitTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -15,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 
 class RevokableTraitTest extends TestCase
 {
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->trait = $this->getMockForTrait(RevokableTrait::class);
     }

--- a/test/Entity/ScopeEntityTest.php
+++ b/test/Entity/ScopeEntityTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2\Entity;

--- a/test/Entity/ScopeEntityTest.php
+++ b/test/Entity/ScopeEntityTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -14,9 +12,11 @@ use League\OAuth2\Server\Entities\ScopeEntityInterface;
 use Mezzio\Authentication\OAuth2\Entity\ScopeEntity;
 use PHPUnit\Framework\TestCase;
 
+use function json_encode;
+
 class ScopeEntityTest extends TestCase
 {
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->entity = new ScopeEntity();
     }

--- a/test/Entity/TimestampableTraitTest.php
+++ b/test/Entity/TimestampableTraitTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2\Entity;

--- a/test/Entity/TimestampableTraitTest.php
+++ b/test/Entity/TimestampableTraitTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -16,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 class TimestampableTraitTest extends TestCase
 {
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->trait = $this->getMockForTrait(TimestampableTrait::class);
     }

--- a/test/Entity/UserEntityTest.php
+++ b/test/Entity/UserEntityTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2\Entity;

--- a/test/Entity/UserEntityTest.php
+++ b/test/Entity/UserEntityTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -20,7 +18,7 @@ class UserEntityTest extends TestCase
     /** @var UserEntity */
     private $entity;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->entity = new UserEntity('foo');
     }

--- a/test/Grant/AuthCodeGrantFactoryTest.php
+++ b/test/Grant/AuthCodeGrantFactoryTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2\Grant;

--- a/test/Grant/AuthCodeGrantFactoryTest.php
+++ b/test/Grant/AuthCodeGrantFactoryTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -24,15 +22,15 @@ class AuthCodeGrantFactoryTest extends TestCase
 
     public function testInvoke()
     {
-        $mockContainer = $this->prophesize(ContainerInterface::class);
-        $mockAuthRepo = $this->prophesize(AuthCodeRepositoryInterface::class);
+        $mockContainer        = $this->prophesize(ContainerInterface::class);
+        $mockAuthRepo         = $this->prophesize(AuthCodeRepositoryInterface::class);
         $mockRefreshTokenRepo = $this->prophesize(RefreshTokenRepositoryInterface::class);
 
         $config = [
             'authentication' => [
-                'auth_code_expire' => 'PT10M',
-                'refresh_token_expire' => 'P1M'
-            ]
+                'auth_code_expire'     => 'PT10M',
+                'refresh_token_expire' => 'P1M',
+            ],
         ];
 
         $mockContainer->has(AuthCodeRepositoryInterface::class)->willReturn(true);

--- a/test/Grant/ClientCredentialsGrantFactoryTest.php
+++ b/test/Grant/ClientCredentialsGrantFactoryTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/test/Grant/ClientCredentialsGrantFactoryTest.php
+++ b/test/Grant/ClientCredentialsGrantFactoryTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2\Grant;

--- a/test/Grant/ImplicitGrantFactoryTest.php
+++ b/test/Grant/ImplicitGrantFactoryTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2\Grant;

--- a/test/Grant/ImplicitGrantFactoryTest.php
+++ b/test/Grant/ImplicitGrantFactoryTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -27,7 +25,7 @@ class ImplicitGrantFactoryTest extends TestCase
         $config = [
             'authentication' => [
                 'auth_code_expire' => 'PT10M',
-            ]
+            ],
         ];
 
         $mockContainer->get('config')->willReturn($config);

--- a/test/Grant/PasswordGrantFactoryTest.php
+++ b/test/Grant/PasswordGrantFactoryTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -24,14 +22,14 @@ class PasswordGrantFactoryTest extends TestCase
 
     public function testInvoke()
     {
-        $mockContainer = $this->prophesize(ContainerInterface::class);
-        $mockUserRepo = $this->prophesize(UserRepositoryInterface::class);
+        $mockContainer        = $this->prophesize(ContainerInterface::class);
+        $mockUserRepo         = $this->prophesize(UserRepositoryInterface::class);
         $mockRefreshTokenRepo = $this->prophesize(RefreshTokenRepositoryInterface::class);
 
         $config = [
             'authentication' => [
-                'refresh_token_expire' => 'P1M'
-            ]
+                'refresh_token_expire' => 'P1M',
+            ],
         ];
 
         $mockContainer->has(UserRepositoryInterface::class)->willReturn(true);

--- a/test/Grant/PasswordGrantFactoryTest.php
+++ b/test/Grant/PasswordGrantFactoryTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2\Grant;

--- a/test/Grant/RefreshTokenGrantFactoryTest.php
+++ b/test/Grant/RefreshTokenGrantFactoryTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -23,13 +21,13 @@ class RefreshTokenGrantFactoryTest extends TestCase
 
     public function testInvoke()
     {
-        $mockContainer = $this->prophesize(ContainerInterface::class);
+        $mockContainer        = $this->prophesize(ContainerInterface::class);
         $mockRefreshTokenRepo = $this->prophesize(RefreshTokenRepositoryInterface::class);
 
         $config = [
             'authentication' => [
-                'refresh_token_expire' => 'P1M'
-            ]
+                'refresh_token_expire' => 'P1M',
+            ],
         ];
 
         $mockContainer->has(RefreshTokenRepositoryInterface::class)->willReturn(true);

--- a/test/Grant/RefreshTokenGrantFactoryTest.php
+++ b/test/Grant/RefreshTokenGrantFactoryTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2\Grant;

--- a/test/OAuth2AdapterFactoryTest.php
+++ b/test/OAuth2AdapterFactoryTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2;

--- a/test/OAuth2AdapterFactoryTest.php
+++ b/test/OAuth2AdapterFactoryTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -40,7 +38,7 @@ class OAuth2AdapterFactoryTest extends TestCase
     /** @var callable */
     private $responseFactory;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->container       = $this->prophesize(ContainerInterface::class);
         $this->resourceServer  = $this->prophesize(ResourceServer::class);
@@ -48,8 +46,8 @@ class OAuth2AdapterFactoryTest extends TestCase
         $this->responseFactory = function () {
             return $this->response->reveal();
         };
-        $this->user = $this->prophesize(UserInterface::class);
-        $this->userFactory = function (
+        $this->user            = $this->prophesize(UserInterface::class);
+        $this->userFactory     = function (
             string $identity,
             array $roles = [],
             array $details = []

--- a/test/OAuth2AdapterTest.php
+++ b/test/OAuth2AdapterTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2;

--- a/test/OAuth2AdapterTest.php
+++ b/test/OAuth2AdapterTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -39,14 +37,14 @@ class OAuth2AdapterTest extends TestCase
     /** @var callable */
     private $userFactory;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->resourceServer  = $this->prophesize(ResourceServer::class);
         $this->response        = $this->prophesize(ResponseInterface::class);
         $this->responseFactory = function () {
             return $this->response->reveal();
         };
-        $this->userFactory = function (
+        $this->userFactory     = function (
             string $identity,
             array $roles = [],
             array $details = []

--- a/test/Pdo/OAuth2PdoMiddlewareTest.php
+++ b/test/Pdo/OAuth2PdoMiddlewareTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2\Pdo;

--- a/test/Pdo/OAuth2PdoMiddlewareTest.php
+++ b/test/Pdo/OAuth2PdoMiddlewareTest.php
@@ -66,13 +66,13 @@ class OAuth2PdoMiddlewareTest extends TestCase
 {
     use ProphecyTrait;
 
-    const DB_FILE        = __DIR__ . '/TestAsset/test_oauth2.sq3';
-    const DB_SCHEMA      = __DIR__ . '/../../data/oauth2.sql';
-    const DB_DATA        = __DIR__ . '/TestAsset/test_data.sql';
-    const PRIVATE_KEY    = __DIR__ . '/../TestAsset/private.key';
-    const ENCRYPTION_KEY = 'T2x2+1OGrElaminasS+01OUmwhOcJiGmE58UD1fllNn6CGcQ=';
+    private const DB_FILE        = __DIR__ . '/TestAsset/test_oauth2.sq3';
+    private const DB_SCHEMA      = __DIR__ . '/../../data/oauth2.sql';
+    private const DB_DATA        = __DIR__ . '/TestAsset/test_data.sql';
+    private const PRIVATE_KEY    = __DIR__ . '/../TestAsset/private.key';
+    private const ENCRYPTION_KEY = 'T2x2+1OGrElaminasS+01OUmwhOcJiGmE58UD1fllNn6CGcQ=';
 
-    const CODE_VERIFIER = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+    private const CODE_VERIFIER = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
 
     /** @var AccessTokenRepository */
     private $accessTokenRepository;

--- a/test/Pdo/OAuth2PdoMiddlewareTest.php
+++ b/test/Pdo/OAuth2PdoMiddlewareTest.php
@@ -294,7 +294,7 @@ class OAuth2PdoMiddlewareTest extends TestCase
      *
      * @see https://oauth2.thephpleague.com/authorization-server/auth-code-grant/
      */
-    public function testProcessGetAuthorizationCode()
+    public function testProcessGetAuthorizationCode(): string
     {
         $grant = new AuthCodeGrant(
             $this->authCodeRepository,
@@ -363,7 +363,7 @@ class OAuth2PdoMiddlewareTest extends TestCase
      *
      * @depends testProcessGetAuthorizationCode
      */
-    public function testProcessFromAuthorizationCode(string $code)
+    public function testProcessFromAuthorizationCode(string $code): string
     {
         $grant = new AuthCodeGrant(
             $this->authCodeRepository,
@@ -511,7 +511,7 @@ class OAuth2PdoMiddlewareTest extends TestCase
         $this->assertNotEmpty($content->refresh_token);
     }
 
-    private function buildConsumerAuthMiddleware(AuthorizationHandler $authHandler)
+    private function buildConsumerAuthMiddleware(AuthorizationHandler $authHandler): object
     {
         return new class ($authHandler) implements RequestHandlerInterface
         {

--- a/test/Repository/Pdo/AbstractRepositoryTest.php
+++ b/test/Repository/Pdo/AbstractRepositoryTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2\Repository\Pdo;

--- a/test/Repository/Pdo/AbstractRepositoryTest.php
+++ b/test/Repository/Pdo/AbstractRepositoryTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -19,7 +17,7 @@ class AbstractRepositoryTest extends TestCase
 {
     use ProphecyTrait;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->pdo = $this->prophesize(PdoService::class);
     }
@@ -32,7 +30,7 @@ class AbstractRepositoryTest extends TestCase
 
     public function testScopesToStringWithEmptyArray()
     {
-        $proxy = new class($this->pdo->reveal()) extends AbstractRepository {
+        $proxy  = new class ($this->pdo->reveal()) extends AbstractRepository {
             public function scopesToString(array $scopes): string
             {
                 return parent::scopesToString($scopes);

--- a/test/Repository/Pdo/AccessTokenRepositoryFactoryTest.php
+++ b/test/Repository/Pdo/AccessTokenRepositoryFactoryTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2\Repository\Pdo;

--- a/test/Repository/Pdo/AccessTokenRepositoryFactoryTest.php
+++ b/test/Repository/Pdo/AccessTokenRepositoryFactoryTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -21,15 +19,13 @@ class AccessTokenRepositoryFactoryTest extends TestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @var ContainerInterface
-     */
+    /** @var ContainerInterface */
     private $container;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->container = $this->prophesize(ContainerInterface::class);
-        $this->pdo = $this->prophesize(PdoService::class);
+        $this->pdo       = $this->prophesize(PdoService::class);
     }
 
     public function testFactory()
@@ -38,7 +34,7 @@ class AccessTokenRepositoryFactoryTest extends TestCase
             ->get(PdoService::class)
             ->willReturn($this->pdo->reveal());
 
-        $factory = (new AccessTokenRepositoryFactory)($this->container->reveal());
+        $factory = (new AccessTokenRepositoryFactory())($this->container->reveal());
         $this->assertInstanceOf(AccessTokenRepository::class, $factory);
     }
 }

--- a/test/Repository/Pdo/AccessTokenRepositoryTest.php
+++ b/test/Repository/Pdo/AccessTokenRepositoryTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2\Repository\Pdo;

--- a/test/Repository/Pdo/AccessTokenRepositoryTest.php
+++ b/test/Repository/Pdo/AccessTokenRepositoryTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -14,7 +12,6 @@ use DateTime;
 use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Entities\ScopeEntityInterface;
-use League\OAuth2\Server\Entities\Traits\AccessTokenTrait;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Exception\UniqueTokenIdentifierConstraintViolationException;
 use Mezzio\Authentication\OAuth2\Entity\AccessTokenEntity;
@@ -23,22 +20,21 @@ use Mezzio\Authentication\OAuth2\Repository\Pdo\PdoService;
 use PDOStatement;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
-
 use Prophecy\PhpUnit\ProphecyTrait;
+
+use function date;
 use function time;
 
 class AccessTokenRepositoryTest extends TestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @var AccessTokenRepository
-     */
+    /** @var AccessTokenRepository */
     private $repo;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
-        $this->pdo = $this->prophesize(PdoService::class);
+        $this->pdo  = $this->prophesize(PdoService::class);
         $this->repo = new AccessTokenRepository($this->pdo->reveal());
     }
 
@@ -168,7 +164,7 @@ class AccessTokenRepositoryTest extends TestCase
 
     public function testGetNewToken()
     {
-        $client = $this->prophesize(ClientEntityInterface::class)->reveal();
+        $client      = $this->prophesize(ClientEntityInterface::class)->reveal();
         $accessToken = $this->repo->getNewToken($client, []);
         $this->assertInstanceOf(AccessTokenEntity::class, $accessToken);
         $this->assertEquals($client, $accessToken->getClient());
@@ -177,8 +173,8 @@ class AccessTokenRepositoryTest extends TestCase
 
     public function testGetNewTokenWithScopeAndIndentifier()
     {
-        $client = $this->prophesize(ClientEntityInterface::class)->reveal();
-        $scopes = [ $this->prophesize(ScopeEntityInterface::class)->reveal() ];
+        $client         = $this->prophesize(ClientEntityInterface::class)->reveal();
+        $scopes         = [$this->prophesize(ScopeEntityInterface::class)->reveal()];
         $userIdentifier = 'foo';
 
         $accessToken = $this->repo->getNewToken($client, $scopes, $userIdentifier);

--- a/test/Repository/Pdo/AuthCodeRepositoryFactoryTest.php
+++ b/test/Repository/Pdo/AuthCodeRepositoryFactoryTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2\Repository\Pdo;

--- a/test/Repository/Pdo/AuthCodeRepositoryFactoryTest.php
+++ b/test/Repository/Pdo/AuthCodeRepositoryFactoryTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -21,15 +19,13 @@ class AuthCodeRepositoryFactoryTest extends TestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @var ContainerInterface
-     */
+    /** @var ContainerInterface */
     private $container;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->container = $this->prophesize(ContainerInterface::class);
-        $this->pdo = $this->prophesize(PdoService::class);
+        $this->pdo       = $this->prophesize(PdoService::class);
     }
 
     public function testFactory()
@@ -38,7 +34,7 @@ class AuthCodeRepositoryFactoryTest extends TestCase
             ->get(PdoService::class)
             ->willReturn($this->pdo->reveal());
 
-        $factory = (new AuthCodeRepositoryFactory)($this->container->reveal());
+        $factory = (new AuthCodeRepositoryFactory())($this->container->reveal());
         $this->assertInstanceOf(AuthCodeRepository::class, $factory);
     }
 }

--- a/test/Repository/Pdo/AuthCodeRepositoryTest.php
+++ b/test/Repository/Pdo/AuthCodeRepositoryTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2\Repository\Pdo;

--- a/test/Repository/Pdo/AuthCodeRepositoryTest.php
+++ b/test/Repository/Pdo/AuthCodeRepositoryTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -20,17 +18,18 @@ use Mezzio\Authentication\OAuth2\Repository\Pdo\PdoService;
 use PDOStatement;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
-
 use Prophecy\PhpUnit\ProphecyTrait;
+
+use function date;
 use function time;
 
 class AuthCodeRepositoryTest extends TestCase
 {
     use ProphecyTrait;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
-        $this->pdo = $this->prophesize(PdoService::class);
+        $this->pdo  = $this->prophesize(PdoService::class);
         $this->repo = new AuthCodeRepository($this->pdo->reveal());
     }
 

--- a/test/Repository/Pdo/ClientRepositoryFactoryTest.php
+++ b/test/Repository/Pdo/ClientRepositoryFactoryTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2\Repository\Pdo;

--- a/test/Repository/Pdo/ClientRepositoryFactoryTest.php
+++ b/test/Repository/Pdo/ClientRepositoryFactoryTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -21,15 +19,13 @@ class ClientRepositoryFactoryTest extends TestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @var ContainerInterface
-     */
+    /** @var ContainerInterface */
     private $container;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->container = $this->prophesize(ContainerInterface::class);
-        $this->pdo = $this->prophesize(PdoService::class);
+        $this->pdo       = $this->prophesize(PdoService::class);
     }
 
     public function testFactory()
@@ -38,7 +34,7 @@ class ClientRepositoryFactoryTest extends TestCase
             ->get(PdoService::class)
             ->willReturn($this->pdo->reveal());
 
-        $factory = (new ClientRepositoryFactory)($this->container->reveal());
+        $factory = (new ClientRepositoryFactory())($this->container->reveal());
         $this->assertInstanceOf(ClientRepository::class, $factory);
     }
 }

--- a/test/Repository/Pdo/ClientRepositoryTest.php
+++ b/test/Repository/Pdo/ClientRepositoryTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2\Repository\Pdo;

--- a/test/Repository/Pdo/ClientRepositoryTest.php
+++ b/test/Repository/Pdo/ClientRepositoryTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -22,9 +20,9 @@ class ClientRepositoryTest extends TestCase
 {
     use ProphecyTrait;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
-        $this->pdo = $this->prophesize(PdoService::class);
+        $this->pdo  = $this->prophesize(PdoService::class);
         $this->repo = new ClientRepository($this->pdo->reveal());
     }
 
@@ -39,7 +37,7 @@ class ClientRepositoryTest extends TestCase
             ->will([$statement, 'reveal']);
 
         $this->assertNull(
-            $this->repo ->getClientEntity('client_id')
+            $this->repo->getClientEntity('client_id')
         );
     }
 
@@ -57,20 +55,20 @@ class ClientRepositoryTest extends TestCase
             ->will([$statement, 'reveal']);
 
         $this->assertNull(
-            $this->repo ->getClientEntity('client_id')
+            $this->repo->getClientEntity('client_id')
         );
     }
 
     public function testGetClientEntityReturnsCorrectEntity()
     {
-        $name = 'foo';
+        $name     = 'foo';
         $redirect = 'bar';
 
         $statement = $this->prophesize(PDOStatement::class);
         $statement->bindParam(':clientIdentifier', 'client_id')->shouldBeCalled();
         $statement->execute()->will(function () use ($statement, $name, $redirect) {
             $statement->fetch()->willReturn([
-                'name' => $name,
+                'name'     => $name,
                 'redirect' => $redirect,
             ]);
             return true;
@@ -102,16 +100,25 @@ class ClientRepositoryTest extends TestCase
     public function invalidGrants()
     {
         return [
-            'personal_access_password_mismatch' => ['authorization_code', [
-                'personal_access_client' => 'personal',
-                'password_client'        => 'password',
-            ]],
-            'personal_access_revoked' => ['personal_access', [
-                'personal_access_client' => false,
-            ]],
-            'password_revoked' => ['password', [
-                'password_client' => false,
-            ]],
+            'personal_access_password_mismatch' => [
+                'authorization_code',
+                [
+                    'personal_access_client' => 'personal',
+                    'password_client'        => 'password',
+                ],
+            ],
+            'personal_access_revoked'           => [
+                'personal_access',
+                [
+                    'personal_access_client' => false,
+                ],
+            ],
+            'password_revoked'                  => [
+                'password',
+                [
+                    'password_client' => false,
+                ],
+            ],
         ];
     }
 
@@ -156,7 +163,7 @@ class ClientRepositoryTest extends TestCase
             ->will([$statement, 'reveal']);
 
         $this->assertFalse(
-            $this->repo ->validateClient(
+            $this->repo->validateClient(
                 'client_id',
                 '',
                 $grantType
@@ -171,7 +178,7 @@ class ClientRepositoryTest extends TestCase
         $statement->execute()->will(function () use ($statement) {
             $statement->fetch()->willReturn([
                 'password_client' => true,
-                'secret' => 'bar',
+                'secret'          => 'bar',
             ]);
             return true;
         });
@@ -183,7 +190,7 @@ class ClientRepositoryTest extends TestCase
         $client = $this->prophesize(ClientEntityInterface::class);
 
         $this->assertFalse(
-            $this->repo ->validateClient(
+            $this->repo->validateClient(
                 'client_id',
                 'foo',
                 'password'
@@ -198,7 +205,7 @@ class ClientRepositoryTest extends TestCase
         $statement->execute()->will(function () use ($statement) {
             $statement->fetch()->willReturn([
                 'password_client' => true,
-                'secret' => null,
+                'secret'          => null,
             ]);
             return true;
         });
@@ -210,7 +217,7 @@ class ClientRepositoryTest extends TestCase
         $client = $this->prophesize(ClientEntityInterface::class);
 
         $this->assertFalse(
-            $this->repo ->validateClient(
+            $this->repo->validateClient(
                 'client_id',
                 'foo',
                 'password'

--- a/test/Repository/Pdo/ClientRepositoryTest.php
+++ b/test/Repository/Pdo/ClientRepositoryTest.php
@@ -97,7 +97,7 @@ class ClientRepositoryTest extends TestCase
         );
     }
 
-    public function invalidGrants()
+    public function invalidGrants(): array
     {
         return [
             'personal_access_password_mismatch' => [
@@ -122,7 +122,7 @@ class ClientRepositoryTest extends TestCase
         ];
     }
 
-    public function testValidateClientReturnsFalseIfNoRowReturned()
+    public function testValidateClientReturnsFalseIfNoRowReturned(): void
     {
         $statement = $this->prophesize(PDOStatement::class);
         $statement->bindParam(':clientIdentifier', 'client_id')->shouldBeCalled();

--- a/test/Repository/Pdo/PdoServiceFactoryTest.php
+++ b/test/Repository/Pdo/PdoServiceFactoryTest.php
@@ -26,7 +26,7 @@ class PdoServiceFactoryTest extends TestCase
         $this->factory   = new PdoServiceFactory();
     }
 
-    public function invalidConfiguration()
+    public function invalidConfiguration(): array
     {
         // @codingStandardsIgnoreStart
         return [

--- a/test/Repository/Pdo/PdoServiceFactoryTest.php
+++ b/test/Repository/Pdo/PdoServiceFactoryTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2\Repository\Pdo;

--- a/test/Repository/Pdo/PdoServiceFactoryTest.php
+++ b/test/Repository/Pdo/PdoServiceFactoryTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -13,6 +11,7 @@ namespace MezzioTest\Authentication\OAuth2\Repository\Pdo;
 use Mezzio\Authentication\OAuth2\Exception;
 use Mezzio\Authentication\OAuth2\Repository\Pdo\PdoService;
 use Mezzio\Authentication\OAuth2\Repository\Pdo\PdoServiceFactory;
+use PDO;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
@@ -21,10 +20,10 @@ class PdoServiceFactoryTest extends TestCase
 {
     use ProphecyTrait;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->container = $this->prophesize(ContainerInterface::class);
-        $this->factory = new PdoServiceFactory();
+        $this->factory   = new PdoServiceFactory();
     }
 
     public function invalidConfiguration()
@@ -79,7 +78,7 @@ class PdoServiceFactoryTest extends TestCase
 
     public function testValidServiceInConfigurationReturnsPdoService()
     {
-        $mockPdo = $this->prophesize(\PDO::class);
+        $mockPdo = $this->prophesize(PDO::class);
 
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn([
@@ -93,7 +92,7 @@ class PdoServiceFactoryTest extends TestCase
 
         $pdo = ($this->factory)($this->container->reveal());
 
-        $this->assertInstanceOf(\PDO::class, $pdo);
+        $this->assertInstanceOf(PDO::class, $pdo);
     }
 
     public function testRaisesExceptionIfPdoServiceIsInvalid()

--- a/test/Repository/Pdo/PdoServiceFactoryTest.php
+++ b/test/Repository/Pdo/PdoServiceFactoryTest.php
@@ -24,7 +24,7 @@ class PdoServiceFactoryTest extends TestCase
 
     public function invalidConfiguration(): array
     {
-        // @codingStandardsIgnoreStart
+        // phpcs:disable
         return [
             'no-config-service'                   => [false, [], 'PDO configuration is missing'],
             'config-empty'                        => [true, [], 'PDO configuration is missing'],
@@ -32,7 +32,7 @@ class PdoServiceFactoryTest extends TestCase
             'config-authentication-pdo-empty'     => [true, ['authentication' => ['pdo' => null]], 'PDO configuration is missing'],
             'config-authentication-pdo-dsn-empty' => [true, ['authentication' => ['pdo' => ['dsn' => null]]], 'DSN configuration is missing'],
         ];
-        // @codingStandardsIgnoreEnd
+        // phpcs:enable
     }
 
     /**

--- a/test/Repository/Pdo/RefreshTokenRepositoryFactoryTest.php
+++ b/test/Repository/Pdo/RefreshTokenRepositoryFactoryTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -21,15 +19,13 @@ class RefreshTokenRepositoryFactoryTest extends TestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @var ContainerInterface
-     */
+    /** @var ContainerInterface */
     private $container;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->container = $this->prophesize(ContainerInterface::class);
-        $this->pdo = $this->prophesize(PdoService::class);
+        $this->pdo       = $this->prophesize(PdoService::class);
     }
 
     public function testFactory()
@@ -38,7 +34,7 @@ class RefreshTokenRepositoryFactoryTest extends TestCase
             ->get(PdoService::class)
             ->willReturn($this->pdo->reveal());
 
-        $factory = (new RefreshTokenRepositoryFactory)($this->container->reveal());
+        $factory = (new RefreshTokenRepositoryFactory())($this->container->reveal());
         $this->assertInstanceOf(RefreshTokenRepository::class, $factory);
     }
 }

--- a/test/Repository/Pdo/RefreshTokenRepositoryFactoryTest.php
+++ b/test/Repository/Pdo/RefreshTokenRepositoryFactoryTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2\Repository\Pdo;

--- a/test/Repository/Pdo/RefreshTokenRepositoryTest.php
+++ b/test/Repository/Pdo/RefreshTokenRepositoryTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2\Repository\Pdo;

--- a/test/Repository/Pdo/RefreshTokenRepositoryTest.php
+++ b/test/Repository/Pdo/RefreshTokenRepositoryTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -20,17 +18,18 @@ use Mezzio\Authentication\OAuth2\Repository\Pdo\RefreshTokenRepository;
 use PDOStatement;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
-
 use Prophecy\PhpUnit\ProphecyTrait;
+
+use function date;
 use function time;
 
 class RefreshTokenRepositoryTest extends TestCase
 {
     use ProphecyTrait;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
-        $this->pdo = $this->prophesize(PdoService::class);
+        $this->pdo  = $this->prophesize(PdoService::class);
         $this->repo = new RefreshTokenRepository($this->pdo->reveal());
     }
 

--- a/test/Repository/Pdo/ScopeRepositoryFactoryTest.php
+++ b/test/Repository/Pdo/ScopeRepositoryFactoryTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2\Repository\Pdo;

--- a/test/Repository/Pdo/ScopeRepositoryFactoryTest.php
+++ b/test/Repository/Pdo/ScopeRepositoryFactoryTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -21,15 +19,13 @@ class ScopeRepositoryFactoryTest extends TestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @var ContainerInterface
-     */
+    /** @var ContainerInterface */
     private $container;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->container = $this->prophesize(ContainerInterface::class);
-        $this->pdo = $this->prophesize(PdoService::class);
+        $this->pdo       = $this->prophesize(PdoService::class);
     }
 
     public function testFactory()
@@ -38,7 +34,7 @@ class ScopeRepositoryFactoryTest extends TestCase
             ->get(PdoService::class)
             ->willReturn($this->pdo->reveal());
 
-        $factory = (new ScopeRepositoryFactory)($this->container->reveal());
+        $factory = (new ScopeRepositoryFactory())($this->container->reveal());
         $this->assertInstanceOf(ScopeRepository::class, $factory);
     }
 }

--- a/test/Repository/Pdo/ScopeRepositoryTest.php
+++ b/test/Repository/Pdo/ScopeRepositoryTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2\Repository\Pdo;

--- a/test/Repository/Pdo/ScopeRepositoryTest.php
+++ b/test/Repository/Pdo/ScopeRepositoryTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -23,9 +21,9 @@ class ScopeRepositoryTest extends TestCase
 {
     use ProphecyTrait;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
-        $this->pdo = $this->prophesize(PdoService::class);
+        $this->pdo  = $this->prophesize(PdoService::class);
         $this->repo = new ScopeRepository($this->pdo->reveal());
     }
 
@@ -63,7 +61,7 @@ class ScopeRepositoryTest extends TestCase
         $statement->bindParam(':identifier', 'id')->shouldBeCalled();
         $statement->execute()->willReturn(true)->shouldBeCalled();
         $statement->fetch()->willReturn([
-            'id' => 'foo'
+            'id' => 'foo',
         ])->shouldBeCalled();
 
         $this->pdo
@@ -78,7 +76,7 @@ class ScopeRepositoryTest extends TestCase
     public function testFinalizeScopesWithEmptyScopes()
     {
         $clientEntity = $this->prophesize(ClientEntityInterface::class);
-        $scopes = $this->repo->finalizeScopes([], 'foo', $clientEntity->reveal());
+        $scopes       = $this->repo->finalizeScopes([], 'foo', $clientEntity->reveal());
         $this->assertEquals([], $scopes);
     }
 }

--- a/test/Repository/Pdo/UserRepositoryTest.php
+++ b/test/Repository/Pdo/UserRepositoryTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -19,13 +17,17 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 
+use function password_hash;
+
+use const PASSWORD_DEFAULT;
+
 class UserRepositoryTest extends TestCase
 {
     use ProphecyTrait;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
-        $this->pdo = $this->prophesize(PdoService::class);
+        $this->pdo  = $this->prophesize(PdoService::class);
         $this->repo = new UserRepository($this->pdo->reveal());
     }
 
@@ -42,7 +44,7 @@ class UserRepositoryTest extends TestCase
         $client = $this->prophesize(ClientEntityInterface::class);
 
         $this->assertNull(
-            $this->repo ->getUserEntityByUserCredentials(
+            $this->repo->getUserEntityByUserCredentials(
                 'username',
                 'password',
                 'auth',
@@ -69,7 +71,7 @@ class UserRepositoryTest extends TestCase
         $client = $this->prophesize(ClientEntityInterface::class);
 
         $this->assertNull(
-            $this->repo ->getUserEntityByUserCredentials(
+            $this->repo->getUserEntityByUserCredentials(
                 'username',
                 'password',
                 'auth',
@@ -94,7 +96,7 @@ class UserRepositoryTest extends TestCase
         $client = $this->prophesize(ClientEntityInterface::class);
 
         $this->assertNull(
-            $this->repo ->getUserEntityByUserCredentials(
+            $this->repo->getUserEntityByUserCredentials(
                 'username',
                 'password',
                 'auth',
@@ -109,7 +111,7 @@ class UserRepositoryTest extends TestCase
         $statement->bindParam(':username', 'username')->shouldBeCalled();
         $statement->execute()->willReturn(true);
         $statement->fetch()->willReturn([
-            'password' => password_hash('password', PASSWORD_DEFAULT)
+            'password' => password_hash('password', PASSWORD_DEFAULT),
         ]);
 
         $this->pdo

--- a/test/Repository/Pdo/UserRepositoryTest.php
+++ b/test/Repository/Pdo/UserRepositoryTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2\Repository\Pdo;

--- a/test/RepositoryTraitTest.php
+++ b/test/RepositoryTraitTest.php
@@ -12,6 +12,7 @@ use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
 use League\OAuth2\Server\Repositories\AuthCodeRepositoryInterface;
 use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
 use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
+use League\OAuth2\Server\Repositories\RepositoryInterface;
 use League\OAuth2\Server\Repositories\ScopeRepositoryInterface;
 use League\OAuth2\Server\Repositories\UserRepositoryInterface;
 use Mezzio\Authentication\OAuth2\Exception;
@@ -29,7 +30,7 @@ class RepositoryTraitTest extends TestCase
         $this->trait     = new class {
             use RepositoryTrait;
 
-            public function proxy(string $name, ContainerInterface $container)
+            public function proxy(string $name, ContainerInterface $container): RepositoryInterface
             {
                 return $this->$name($container);
             }

--- a/test/RepositoryTraitTest.php
+++ b/test/RepositoryTraitTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2;

--- a/test/RepositoryTraitTest.php
+++ b/test/RepositoryTraitTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -26,9 +24,9 @@ class RepositoryTraitTest extends TestCase
 {
     use ProphecyTrait;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
-        $this->trait = new class {
+        $this->trait     = new class {
             use RepositoryTrait;
 
             public function proxy(string $name, ContainerInterface $container)

--- a/test/ResourceServerFactoryTest.php
+++ b/test/ResourceServerFactoryTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2;

--- a/test/ResourceServerFactoryTest.php
+++ b/test/ResourceServerFactoryTest.php
@@ -21,9 +21,9 @@ class ResourceServerFactoryTest extends TestCase
 {
     use ProphecyTrait;
 
-    const PUBLIC_KEY = __DIR__ . '/TestAsset/public.key';
+    private const PUBLIC_KEY = __DIR__ . '/TestAsset/public.key';
 
-    const PUBLIC_KEY_EXTENDED = [
+    private const PUBLIC_KEY_EXTENDED = [
         'key_or_path'           => self::PUBLIC_KEY,
         'pass_phrase'           => 'test',
         'key_permissions_check' => false,

--- a/test/ResourceServerFactoryTest.php
+++ b/test/ResourceServerFactoryTest.php
@@ -2,14 +2,13 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2;
 
+use Generator;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
 use League\OAuth2\Server\ResourceServer;
 use Mezzio\Authentication\OAuth2\Exception;
@@ -25,14 +24,14 @@ class ResourceServerFactoryTest extends TestCase
     const PUBLIC_KEY = __DIR__ . '/TestAsset/public.key';
 
     const PUBLIC_KEY_EXTENDED = [
-        'key_or_path' => self::PUBLIC_KEY,
-        'pass_phrase' => 'test',
+        'key_or_path'           => self::PUBLIC_KEY,
+        'pass_phrase'           => 'test',
         'key_permissions_check' => false,
     ];
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
-        $this->container  = $this->prophesize(ContainerInterface::class);
+        $this->container = $this->prophesize(ContainerInterface::class);
     }
 
     public function testConstructor()
@@ -56,8 +55,8 @@ class ResourceServerFactoryTest extends TestCase
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn([
             'authentication' => [
-                'public_key' => self::PUBLIC_KEY
-            ]
+                'public_key' => self::PUBLIC_KEY,
+            ],
         ]);
         $this->container
             ->has(AccessTokenRepositoryInterface::class)
@@ -74,8 +73,8 @@ class ResourceServerFactoryTest extends TestCase
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn([
             'authentication' => [
-                'public_key' => self::PUBLIC_KEY
-            ]
+                'public_key' => self::PUBLIC_KEY,
+            ],
         ]);
         $this->container
             ->has(AccessTokenRepositoryInterface::class)
@@ -86,12 +85,12 @@ class ResourceServerFactoryTest extends TestCase
                 $this->prophesize(AccessTokenRepositoryInterface::class)->reveal()
             );
 
-        $factory = new ResourceServerFactory();
+        $factory        = new ResourceServerFactory();
         $resourceServer = $factory($this->container->reveal());
         $this->assertInstanceOf(ResourceServer::class, $resourceServer);
     }
 
-    public function getExtendedKeyConfigs(): \Generator
+    public function getExtendedKeyConfigs(): Generator
     {
         $extendedConfig = self::PUBLIC_KEY_EXTENDED;
 
@@ -112,8 +111,8 @@ class ResourceServerFactoryTest extends TestCase
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn([
             'authentication' => [
-                'public_key' => $keyConfig
-            ]
+                'public_key' => $keyConfig,
+            ],
         ]);
         $this->container
             ->has(AccessTokenRepositoryInterface::class)
@@ -124,12 +123,12 @@ class ResourceServerFactoryTest extends TestCase
                 $this->prophesize(AccessTokenRepositoryInterface::class)->reveal()
             );
 
-        $factory = new ResourceServerFactory();
+        $factory        = new ResourceServerFactory();
         $resourceServer = $factory($this->container->reveal());
         $this->assertInstanceOf(ResourceServer::class, $resourceServer);
     }
 
-    public function getInvalidExtendedKeyConfigs(): \Generator
+    public function getInvalidExtendedKeyConfigs(): Generator
     {
         $extendedConfig = self::PUBLIC_KEY_EXTENDED;
 
@@ -145,8 +144,8 @@ class ResourceServerFactoryTest extends TestCase
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn([
             'authentication' => [
-                'public_key' => $keyConfig
-            ]
+                'public_key' => $keyConfig,
+            ],
         ]);
         $this->container
             ->has(AccessTokenRepositoryInterface::class)

--- a/test/TokenEndpointHandlerFactoryTest.php
+++ b/test/TokenEndpointHandlerFactoryTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -11,14 +9,12 @@ declare(strict_types=1);
 namespace MezzioTest\Authentication\OAuth2;
 
 use League\OAuth2\Server\AuthorizationServer;
-use League\OAuth2\Server\RequestTypes\AuthorizationRequest;
 use Mezzio\Authentication\OAuth2\TokenEndpointHandler;
 use Mezzio\Authentication\OAuth2\TokenEndpointHandlerFactory;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
 use TypeError;
 
 /**
@@ -28,12 +24,10 @@ class TokenEndpointHandlerFactoryTest extends TestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @var TokenEndpointHandlerFactory
-     */
+    /** @var TokenEndpointHandlerFactory */
     private $subject;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->subject = new TokenEndpointHandlerFactory();
         parent::setUp();
@@ -49,10 +43,10 @@ class TokenEndpointHandlerFactoryTest extends TestCase
 
     public function testCreatesTokenEndpointHandler()
     {
-        $server = $this->prophesize(AuthorizationServer::class);
+        $server          = $this->prophesize(AuthorizationServer::class);
         $responseFactory = function () {
         };
-        $container = $this->prophesize(ContainerInterface::class);
+        $container       = $this->prophesize(ContainerInterface::class);
 
         $container->get(AuthorizationServer::class)
             ->willReturn($server->reveal());
@@ -64,7 +58,7 @@ class TokenEndpointHandlerFactoryTest extends TestCase
 
     public function testDirectResponseInstanceFromContainerThrowsTypeError()
     {
-        $server = $this->prophesize(AuthorizationServer::class);
+        $server    = $this->prophesize(AuthorizationServer::class);
         $container = $this->prophesize(ContainerInterface::class);
 
         $container->get(AuthorizationServer::class)

--- a/test/TokenEndpointHandlerFactoryTest.php
+++ b/test/TokenEndpointHandlerFactoryTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2;

--- a/test/TokenEndpointHandlerTest.php
+++ b/test/TokenEndpointHandlerTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 namespace MezzioTest\Authentication\OAuth2;

--- a/test/TokenEndpointHandlerTest.php
+++ b/test/TokenEndpointHandlerTest.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
@@ -27,7 +25,7 @@ class TokenEndpointHandlerTest extends TestCase
 {
     use ProphecyTrait;
 
-    private function createResponseFactory(ResponseInterface $response = null): callable
+    private function createResponseFactory(?ResponseInterface $response = null): callable
     {
         return function () use ($response): ResponseInterface {
             return $response ?? $this->prophesize(ResponseInterface::class)->reveal();
@@ -36,9 +34,9 @@ class TokenEndpointHandlerTest extends TestCase
 
     public function testHandleUsesAuthorizationServer()
     {
-        $server = $this->prophesize(AuthorizationServer::class);
-        $request = $this->prophesize(ServerRequestInterface::class);
-        $response = $this->prophesize(ResponseInterface::class);
+        $server           = $this->prophesize(AuthorizationServer::class);
+        $request          = $this->prophesize(ServerRequestInterface::class);
+        $response         = $this->prophesize(ResponseInterface::class);
         $expectedResponse = $response->reveal();
 
         $server->respondToAccessTokenRequest($request->reveal(), $expectedResponse)
@@ -51,10 +49,10 @@ class TokenEndpointHandlerTest extends TestCase
 
     public function testOAuthExceptionProducesResult()
     {
-        $server = $this->prophesize(AuthorizationServer::class);
-        $request = $this->prophesize(ServerRequestInterface::class);
-        $response = $this->prophesize(ResponseInterface::class);
-        $exception = $this->prophesize(OAuthServerException::class);
+        $server           = $this->prophesize(AuthorizationServer::class);
+        $request          = $this->prophesize(ServerRequestInterface::class);
+        $response         = $this->prophesize(ResponseInterface::class);
+        $exception        = $this->prophesize(OAuthServerException::class);
         $expectedResponse = $response->reveal();
 
         $server->respondToAccessTokenRequest(Argument::cetera())
@@ -70,8 +68,8 @@ class TokenEndpointHandlerTest extends TestCase
 
     public function testGenericExceptionsFallsThrough()
     {
-        $server = $this->prophesize(AuthorizationServer::class);
-        $request = $this->prophesize(ServerRequestInterface::class);
+        $server    = $this->prophesize(AuthorizationServer::class);
+        $request   = $this->prophesize(ServerRequestInterface::class);
         $exception = new RuntimeException();
 
         $server->respondToAccessTokenRequest(Argument::cetera())

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -2,8 +2,6 @@
 
 /**
  * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- * @copyright https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/COPYRIGHT.md
- * @license   https://github.com/mezzio/mezzio-authentication-oauth2/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-authentication-oauth2 for the canonical source repository
- */
-
 declare(strict_types=1);
 
 // change the permission of private and public keys to 0600


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | yes

### Description

This patch rebases #37 to the 2.4.x branch (sorry, @aruekauer — your branch appears to have disappeared! But these ARE all your commits!), updating the laminas-coding-standard version to the 2.3 series.

