### PR TITLE
Revert BC break - allow `array` structures for private keys, rather than just `string`

### DIFF
--- a/src/ConfigTrait.php
+++ b/src/ConfigTrait.php
@@ -11,7 +11,8 @@ use function is_array;
 
 trait ConfigTrait
 {
-    protected function getPrivateKey(ContainerInterface $container): string
+    /** @return non-empty-string|non-empty-array */
+    protected function getPrivateKey(ContainerInterface $container)
     {
         $config = $container->get('config')['authentication'] ?? [];
 

--- a/test/ConfigTraitTest.php
+++ b/test/ConfigTraitTest.php
@@ -59,6 +59,26 @@ class ConfigTraitTest extends TestCase
         $this->assertEquals($this->config['authentication']['private_key'], $result);
     }
 
+    public function testGetPrivateKeyArray()
+    {
+        $config = [
+            'authentication' => [
+                'private_key' => [
+                    'key_or_path'           => 'xxx',
+                    'pass_phrase'           => 'test',
+                    'key_permissions_check' => false,
+                ],
+            ],
+        ];
+
+        $this->container
+            ->get('config')
+            ->willReturn($config);
+
+        $result = $this->trait->proxy('getPrivateKey', $this->container->reveal());
+        $this->assertEquals($config['authentication']['private_key'], $result);
+    }
+
     public function testGetEncryptionKeyNoConfig()
     {
         $this->container


### PR DESCRIPTION
`\Mezzio\Authentication\OAuth2\ConfigTrait::getPrivateKey()` - should not force string only configuration for private key


|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | yes
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Fixes #47
